### PR TITLE
[cuDNN] Add basic support for constructing cuDNN graphs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/cudnn-frontend"]
+	path = third_party/cudnn-frontend
+	url = git@github.com:NVIDIA/cudnn-frontend.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 The IREE Authors
+# Copyright 2023 The OpenXLA Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 The OpenXLA Authors
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
@@ -6,14 +6,20 @@
 
 cmake_minimum_required(VERSION 3.21...3.24)
 
+project(OPENXLA_NVGPU)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-project(OPENXLA_NVGPU)
+set(CMAKE_CXX_STANDARD 17)
+
+set(OPENXLA_NVGPU_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # TODO: Fix this once the project is slotted into place.
 if(NOT IREE_ROOT_DIR)
   set(IREE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../iree")
 endif()
+
+set(IREE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 
 # Customize defaults.
 option(IREE_BUILD_COMPILER "Disable compiler for runtime-library build" ON)
@@ -24,13 +30,12 @@ option(IREE_TARGET_BACKEND_DEFAULTS "Disables target backend" OFF)
 option(IREE_TARGET_BACKEND_CUDA "Enables CUDA target backend" ON)
 option(IREE_COMPILER_BUILD_SHARED_LIBS "Enables shared libraries in the compiler by default" ON)
 
-# TODO: `llvm-cpu` compiler backend and `local-sync` HAL driver are enabled only
-# for running tests. Diable them once we'll use proper CUDA target and driver.
-option(IREE_HAL_DRIVER_LOCAL_SYNC "Enables the 'local-sync' runtime HAL driver" ON)
-option(IREE_TARGET_BACKEND_LLVM_CPU "Enables the 'llvm-cpu' target backend" ON)
-
 set(IREE_COMPILER_PLUGIN_PATHS "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING "OpenXLA nvgpu plugins")
 add_subdirectory("${IREE_ROOT_DIR}" "iree_core")
+
+# Handle various global definitions that need to be set at the global
+# toolchain level.
+iree_setup_toolchain()
 
 #-------------------------------------------------------------------------------
 # OpenXLA NVGPU Runtime.
@@ -38,8 +43,11 @@ add_subdirectory("${IREE_ROOT_DIR}" "iree_core")
 # Integration of NVIDIA libraries with IREE runtime via custom VM modules.
 #-------------------------------------------------------------------------------
 
-# TODO: Use same compiler flags for building runtime targets as the IREE core.
-set(IREE_CXX_STANDARD 17)
-
 add_subdirectory(runtime)
 add_subdirectory(tools)
+
+#-------------------------------------------------------------------------------
+# NVIDIA dependencies
+#-------------------------------------------------------------------------------
+
+add_subdirectory(build_tools/third_party/cudnn-frontend EXCLUDE_FROM_ALL)

--- a/build_tools/third_party/cudnn-frontend/CMakeLists.txt
+++ b/build_tools/third_party/cudnn-frontend/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(CUDNN_FRONTEND_ROOT "${OPENXLA_NVGPU_ROOT_DIR}/third_party/cudnn-frontend/")
+
+external_cc_library(
+  PACKAGE
+    cudnn_frontend
+  NAME
+    cudnn_frontend
+  ROOT
+    ${CUDNN_FRONTEND_ROOT}
+  INCLUDES
+    "${CUDNN_FRONTEND_ROOT}/include"    
+  HDRS
+    "include/cudnn_frontend.h"
+  PUBLIC
+)

--- a/runtime/src/CMakeLists.txt
+++ b/runtime/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 The IREE Authors
+# Copyright 2023 The OpenXLA Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/runtime/src/CMakeLists.txt
+++ b/runtime/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023 The OpenXLA Authors
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/runtime/src/openxla/runtime/nvgpu/CMakeLists.txt
+++ b/runtime/src/openxla/runtime/nvgpu/CMakeLists.txt
@@ -25,7 +25,24 @@ iree_cc_library(
   DEPS
     ::defs
     ::dynamic_symbols
+    ::cudnn_api
     iree::runtime
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    cudnn_api
+  HDRS
+    "cudnn_api.h"
+  SRCS
+    "cudnn_api.cpp"
+  DEPS
+    ::defs
+    ::dynamic_symbols
+    ::cudnn_stub
+    cudnn_frontend
+    iree::vm
   PUBLIC
 )
 
@@ -50,5 +67,20 @@ iree_cc_library(
     # TODO: We rely on the fact that cuDNN headers are located in the same
     # directory as CUDA headers. Fix this.
     iree_cuda::headers
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    cudnn_stub
+  HDRS
+    "cudnn_stub.h"
+  TEXTUAL_HDRS
+    "cudnn_stub.h.inc"
+  SRCS
+    "cudnn_stub.cpp"
+  DEPS
+    ::defs
+    ::dynamic_symbols
   PUBLIC
 )

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_api.cpp
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_api.cpp
@@ -1,0 +1,215 @@
+// Copyright 2023 The OpenXLA Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "openxla/runtime/nvgpu/cudnn_api.h"
+
+#include <iree/base/internal/span.h>
+#include <iree/base/status.h>
+#include <iree/base/status_cc.h>
+#include <iree/vm/ref_cc.h>
+#include <openxla/runtime/nvgpu/status_util.h>
+
+#include <type_traits>
+
+#include "openxla/runtime/nvgpu/cudnn_stub.h"
+
+namespace openxla::runtime::nvgpu {
+
+using namespace iree;
+
+using cudnn_frontend::TensorBuilder;
+
+// clang-format off
+#include "openxla/runtime/nvgpu/cudnn_stub.h.inc"
+// clang-format on
+
+//===----------------------------------------------------------------------===//
+// CuDNNArgTensor.
+//===----------------------------------------------------------------------===//
+
+CuDNNArgTensor::CuDNNArgTensor(openxla_cudnn_dynamic_symbols_t* syms,
+                               cudnn_frontend::Tensor tensor)
+    : CuDNNTensor(Kind::kArg), syms_(syms), tensor_(std::move(tensor)) {}
+
+CuDNNArgTensor::~CuDNNArgTensor() {
+  ScopedCuDNNStubs stubs(syms_);
+  tensor_.reset();
+}
+
+const cudnn_frontend::Tensor& CuDNNArgTensor::tensor() const {
+  return *tensor_;
+}
+
+//===----------------------------------------------------------------------===//
+// CuDNNOpResultTensor.
+//===----------------------------------------------------------------------===//
+
+CuDNNOpResultTensor::CuDNNOpResultTensor(openxla_cudnn_dynamic_symbols_t* syms,
+                                         iree::span<CuDNNTensor* const> inputs,
+                                         cudnn_frontend::Operation operation,
+                                         cudnn_frontend::Tensor tensor)
+    : CuDNNTensor(Kind::kOpResult),
+      syms_(syms),
+      operation_(std::move(operation)),
+      tensor_(std::move(tensor)) {
+  for (CuDNNTensor* input : inputs) {
+    inputs_.push_back(vm::retain_ref(input));
+  }
+}
+
+CuDNNOpResultTensor::~CuDNNOpResultTensor() {
+  ScopedCuDNNStubs stubs(syms_);
+  operation_.reset();
+  tensor_.reset();
+}
+
+std::vector<CuDNNTensor*> CuDNNOpResultTensor::inputs() const {
+  std::vector<CuDNNTensor*> ptrs;
+  for (auto& input : inputs_) ptrs.push_back(input.get());
+  return ptrs;
+}
+
+const cudnn_frontend::Operation* CuDNNOpResultTensor::operation() const {
+  return &*operation_;
+}
+
+const cudnn_frontend::Tensor& CuDNNOpResultTensor::tensor() const {
+  return *tensor_;
+}
+
+//===----------------------------------------------------------------------===//
+// CuDNNOperationGraph.
+//===----------------------------------------------------------------------===//
+
+CuDNNOperationGraph::CuDNNOperationGraph(openxla_cudnn_dynamic_symbols_t* syms,
+                                         cudnn_frontend::OperationGraph graph)
+    : syms_(syms), graph_(std::move(graph)) {}
+
+CuDNNOperationGraph::~CuDNNOperationGraph() {
+  ScopedCuDNNStubs stubs(syms_);
+  graph_.reset();
+}
+
+const cudnn_frontend::OperationGraph& CuDNNOperationGraph::graph() const {
+  return *graph_;
+}
+
+//===----------------------------------------------------------------------===//
+// Wrappers around cuDNN APIs export from a cuDNN module to the user.
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// CreateArgument.
+//===----------------------------------------------------------------------===//
+
+StatusOr<vm::ref<CuDNNTensor>> CreateArgument(
+    openxla_cudnn_dynamic_symbols_t* syms, span<const int64_t> dims,
+    span<const int64_t> strides, int64_t uid, cudnnDataType_t dtype,
+    int64_t alignment) {
+  ScopedCuDNNStubs stubs(syms);
+  cudnn_frontend::Tensor tensor = cudnn_frontend::TensorBuilder()
+                                      .setDim(dims.size(), dims.data())
+                                      .setStride(strides.size(), strides.data())
+                                      .setId(uid)
+                                      .setAlignment(alignment)
+                                      .setDataType(dtype)
+                                      .build();
+  IREE_RETURN_IF_ERROR(CUDNN_CONVERT_STATUS(syms, tensor.get_status()));
+  return vm::ref<CuDNNTensor>(new CuDNNArgTensor(syms, std::move(tensor)));
+}
+
+//===----------------------------------------------------------------------===//
+// CreatePointwiseRelu.
+//===----------------------------------------------------------------------===//
+
+StatusOr<vm::ref<CuDNNTensor>> CreatePointwiseRelu(
+    openxla_cudnn_dynamic_symbols_t* syms, CuDNNTensor& input,
+    double lower_clip, double upper_clip, int64_t uid, int64_t alignment) {
+  ScopedCuDNNStubs stubs(syms);
+
+  // Prepare tensor descriptor for activation output.
+  cudnn_frontend::Tensor tensor = cudnn_frontend::TensorBuilder()
+                                      .cloneFrom(input.tensor(), uid)
+                                      .setAlignment(alignment)
+                                      .build();
+  IREE_RETURN_IF_ERROR(CUDNN_CONVERT_STATUS(syms, tensor.get_status()));
+
+  // Prepare activation descriptor.
+  cudnn_frontend::PointWiseDesc activation =
+      cudnn_frontend::PointWiseDescBuilder()
+          .setMode(CUDNN_POINTWISE_RELU_FWD)
+          .setClipping(lower_clip, upper_clip)
+          .build();
+  IREE_RETURN_IF_ERROR(CUDNN_CONVERT_STATUS(syms, activation.get_status()));
+
+  // Create operation.
+  cudnn_frontend::Operation operation =
+      cudnn_frontend::OperationBuilder(
+          CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+          .setxDesc(input.tensor())
+          .setyDesc(tensor)
+          .setpwDesc(activation)
+          .build();
+  IREE_RETURN_IF_ERROR(CUDNN_CONVERT_STATUS(syms, operation.get_status()));
+
+  return vm::ref<CuDNNTensor>(new CuDNNOpResultTensor(
+      syms, {&input}, std::move(operation), std::move(tensor)));
+}
+
+//===----------------------------------------------------------------------===//
+// CreateOperationGraph.
+//===----------------------------------------------------------------------===//
+
+template <typename To>
+static To* DynCast(CuDNNTensor* tensor) {
+  return To::classof(tensor) ? static_cast<To*>(tensor) : nullptr;
+}
+
+StatusOr<vm::ref<CuDNNOperationGraph>> CreateOperationGraph(
+    openxla_cudnn_dynamic_symbols_t* syms, cudnnHandle_t handle,
+    span<CuDNNTensor* const> results) {
+  ScopedCuDNNStubs stubs(syms);
+
+  // Collect cuDNN operations producing tensor results.
+  std::vector<CuDNNTensor*> worklist(results.begin(), results.end());
+  std::vector<const cudnn_frontend::Operation*> ops;
+
+  // TODO(ezhulenev): Take care of duplicate operations when traversing a tensor
+  // use-def chains (with an end-to-end test once we'll support them).
+
+  while (!worklist.empty()) {
+    CuDNNTensor* tensor = worklist.back();
+    worklist.pop_back();
+
+    // Add cudnn_frontend operation and follow inputs.
+    if (auto* op_result = DynCast<CuDNNOpResultTensor>(tensor)) {
+      ops.push_back(op_result->operation());
+      std::vector<CuDNNTensor*> inputs = op_result->inputs();
+      worklist.insert(worklist.end(), inputs.begin(), inputs.end());
+    }
+  }
+
+  // Construct a cudnn_frontend operation graph.
+  auto graph = cudnn_frontend::OperationGraphBuilder()
+                   .setHandle(handle)
+                   .setOperationGraph(ops.size(), ops.data())
+                   .build();
+  IREE_RETURN_IF_ERROR(CUDNN_CONVERT_STATUS(syms, graph.get_status()));
+
+  return vm::ref<CuDNNOperationGraph>(
+      new CuDNNOperationGraph(syms, std::move(graph)));
+}
+
+}  // namespace openxla::runtime::nvgpu
+
+//===----------------------------------------------------------------------===//
+// Register types with IREE VM.
+//===----------------------------------------------------------------------===//
+
+IREE_VM_DEFINE_TYPE_ADAPTERS(cudnn_tensor,
+                             openxla::runtime::nvgpu::CuDNNTensor);
+IREE_VM_DEFINE_TYPE_ADAPTERS(cudnn_operation_graph,
+                             openxla::runtime::nvgpu::CuDNNOperationGraph);

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_api.h
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_api.h
@@ -1,0 +1,147 @@
+// Copyright 2023 The OpenXLA Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef OPENXLA_RUNTIME_NVGPU_CUDNN_API_H_
+#define OPENXLA_RUNTIME_NVGPU_CUDNN_API_H_
+
+#define NV_CUDNN_DISABLE_EXCEPTION
+
+#include <cudnn_frontend.h>
+#include <iree/vm/ref_cc.h>
+
+#include <optional>
+
+#include "iree/base/internal/span.h"
+#include "iree/vm/api.h"
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+namespace openxla::runtime::nvgpu {
+
+// OpenXLA wrappers around cudnn_frontend primitives to simplify operation graph
+// construction and execution. We rely on cudnn_frontend to provide C++ RAII
+// wrappers for all cuDNN Graph API backend descriptors.
+
+//===----------------------------------------------------------------------===//
+// cuDNN tensor representing an abstract shaped and typed block of memory.
+//===----------------------------------------------------------------------===//
+
+class CuDNNTensor : public iree::vm::RefObject<CuDNNTensor> {
+ public:
+  enum class Kind { kArg, kOpResult };
+
+  explicit CuDNNTensor(Kind kind) : kind_(kind) {}
+  virtual ~CuDNNTensor() = default;
+
+  virtual const cudnn_frontend::Tensor& tensor() const = 0;
+
+  Kind kind() const { return kind_; }
+
+ private:
+  Kind kind_;
+};
+
+//===----------------------------------------------------------------------===//
+// Tensor corresponding to the cuDNN graph arguments.
+//===----------------------------------------------------------------------===//
+
+class CuDNNArgTensor final : public CuDNNTensor {
+ public:
+  CuDNNArgTensor(openxla_cudnn_dynamic_symbols_t* syms,
+                 cudnn_frontend::Tensor tensor);
+  ~CuDNNArgTensor() override;
+
+  const cudnn_frontend::Tensor& tensor() const override;
+
+  static bool classof(const CuDNNTensor* tensor) {
+    return tensor->kind() == Kind::kArg;
+  }
+
+ private:
+  openxla_cudnn_dynamic_symbols_t* syms_;
+  std::optional<cudnn_frontend::Tensor> tensor_;
+};
+
+//===----------------------------------------------------------------------===//
+// Tensor corresponding to the cuDNN operation result.
+//===----------------------------------------------------------------------===//
+
+class CuDNNOpResultTensor final : public CuDNNTensor {
+ public:
+  CuDNNOpResultTensor(openxla_cudnn_dynamic_symbols_t* syms,
+                      iree::span<CuDNNTensor* const> inputs,
+                      cudnn_frontend::Operation operation,
+                      cudnn_frontend::Tensor tensor);
+  ~CuDNNOpResultTensor() override;
+
+  std::vector<CuDNNTensor*> inputs() const;
+  const cudnn_frontend::Operation* operation() const;
+  const cudnn_frontend::Tensor& tensor() const override;
+
+  static bool classof(const CuDNNTensor* tensor) {
+    return tensor->kind() == Kind::kOpResult;
+  }
+
+ private:
+  openxla_cudnn_dynamic_symbols_t* syms_;
+
+  // Tensors inputs to the cuDNN operation. We need to keep a reference to them
+  // to be able to traverse use-def chains when building an operation graph.
+  std::vector<iree::vm::ref<CuDNNTensor>> inputs_;
+
+  // cuDNN operation that computes the result tensor.
+  std::optional<cudnn_frontend::Operation> operation_;
+  std::optional<cudnn_frontend::Tensor> tensor_;
+};
+
+//===----------------------------------------------------------------------===//
+// CuDNN operation graph.
+//===----------------------------------------------------------------------===//
+
+class CuDNNOperationGraph : public iree::vm::RefObject<CuDNNOperationGraph> {
+ public:
+  CuDNNOperationGraph(openxla_cudnn_dynamic_symbols_t* syms,
+                      cudnn_frontend::OperationGraph graph);
+  ~CuDNNOperationGraph();
+
+  const cudnn_frontend::OperationGraph& graph() const;
+
+ private:
+  openxla_cudnn_dynamic_symbols_t* syms_;
+  std::optional<cudnn_frontend::OperationGraph> graph_;
+};
+
+//===----------------------------------------------------------------------===//
+// Wrappers around cuDNN APIs export from a cuDNN module to the user.
+//===----------------------------------------------------------------------===//
+
+// Creates a tensor placeholder for cuDNN graph argument.
+iree::StatusOr<iree::vm::ref<CuDNNTensor>> CreateArgument(
+    openxla_cudnn_dynamic_symbols_t* syms, iree::span<const int64_t> dims,
+    iree::span<const int64_t> strides, int64_t uid, cudnnDataType_t dtype,
+    int64_t alignment);
+
+// Creates a pointwise relu operation.
+iree::StatusOr<iree::vm::ref<CuDNNTensor>> CreatePointwiseRelu(
+    openxla_cudnn_dynamic_symbols_t* syms, CuDNNTensor& input,
+    double lower_clip, double upper_clip, int64_t uid, int64_t alignment);
+
+// Creates an operation graph computing tensor results.
+iree::StatusOr<iree::vm::ref<CuDNNOperationGraph>> CreateOperationGraph(
+    openxla_cudnn_dynamic_symbols_t* syms, cudnnHandle_t handle,
+    iree::span<CuDNNTensor* const> results);
+
+}  // namespace openxla::runtime::nvgpu
+
+//===----------------------------------------------------------------------===//
+// Register types with IREE VM.
+//===----------------------------------------------------------------------===//
+
+IREE_VM_DECLARE_TYPE_ADAPTERS(cudnn_tensor,
+                              openxla::runtime::nvgpu::CuDNNTensor);
+IREE_VM_DECLARE_TYPE_ADAPTERS(cudnn_operation_graph,
+                              openxla::runtime::nvgpu::CuDNNOperationGraph);
+
+#endif  // OPENXLA_RUNTIME_NVGPU_CUDNN_API_H_

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_module.h
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_module.h
@@ -20,6 +20,9 @@ iree_status_t iree_custom_module_cudnn_create(iree_vm_instance_t* instance,
                                               iree_allocator_t host_allocator,
                                               iree_vm_module_t** out_module);
 
+iree_status_t iree_custom_module_cudnn_register_types(
+    iree_vm_instance_t* instance);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_stub.cpp
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_stub.cpp
@@ -1,0 +1,24 @@
+// Copyright 2023 The OpenXLA Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "openxla/runtime/nvgpu/cudnn_stub.h"
+
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+namespace openxla::runtime::nvgpu {
+
+static thread_local openxla_cudnn_dynamic_symbols_t* cudnn_syms = nullptr;
+
+ScopedCuDNNStubs::ScopedCuDNNStubs(openxla_cudnn_dynamic_symbols_t* syms)
+    : syms_(cudnn_syms) {
+  cudnn_syms = syms;
+}
+
+ScopedCuDNNStubs::~ScopedCuDNNStubs() { cudnn_syms = syms_; }
+
+openxla_cudnn_dynamic_symbols_t* ScopedCuDNNStubs::syms() { return cudnn_syms; }
+
+}  // namespace openxla::runtime::nvgpu

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_stub.h
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_stub.h
@@ -1,0 +1,28 @@
+// Copyright 2023 The OpenXLA Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef OPENXLA_RUNTIME_NVGPU_CUDNN_STUB_H_
+#define OPENXLA_RUNTIME_NVGPU_CUDNN_STUB_H_
+
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+namespace openxla::runtime::nvgpu {
+
+// RAII helper to bind cuDNN stubs to dynamically resolved symbols.
+class ScopedCuDNNStubs {
+ public:
+  ScopedCuDNNStubs(openxla_cudnn_dynamic_symbols_t* syms);
+  ~ScopedCuDNNStubs();
+
+  static openxla_cudnn_dynamic_symbols_t* syms();
+
+ private:
+  openxla_cudnn_dynamic_symbols_t* syms_;
+};
+
+}  // namespace openxla::runtime::nvgpu
+
+#endif  // OPENXLA_RUNTIME_NVGPU_CUDNN_STUB_H_

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_stub.h.inc
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_stub.h.inc
@@ -1,0 +1,58 @@
+// Copyright 2023 The OpenXLA Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "openxla/runtime/nvgpu/cudnn_stub.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// cuDNN API required for compiling cudnn_frontend.
+//===----------------------------------------------------------------------===//
+
+cudnnStatus_t CUDNNWINAPI
+cudnnBackendSetAttribute(cudnnBackendDescriptor_t descriptor,
+                         cudnnBackendAttributeName_t attributeName,
+                         cudnnBackendAttributeType_t attributeType,
+                         int64_t elementCount, const void* arrayOfElements) {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnBackendSetAttribute(
+      descriptor, attributeName, attributeType, elementCount, arrayOfElements);
+}
+
+cudnnStatus_t CUDNNWINAPI
+cudnnBackendCreateDescriptor(cudnnBackendDescriptorType_t descriptorType,
+                             cudnnBackendDescriptor_t* descriptor) {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnBackendCreateDescriptor(descriptorType, descriptor);
+}
+
+cudnnStatus_t CUDNNWINAPI
+cudnnBackendDestroyDescriptor(cudnnBackendDescriptor_t descriptor) {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnBackendDestroyDescriptor(descriptor);
+}
+
+cudnnStatus_t CUDNNWINAPI
+cudnnBackendFinalize(cudnnBackendDescriptor_t descriptor) {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnBackendFinalize(descriptor);
+}
+
+size_t CUDNNWINAPI cudnnGetVersion() {
+  auto* syms = openxla::runtime::nvgpu::ScopedCuDNNStubs::syms();
+  IREE_ASSERT(syms);
+  return syms->cudnnGetVersion();
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/runtime/src/openxla/runtime/nvgpu/dynamic_symbol_tables.h
+++ b/runtime/src/openxla/runtime/nvgpu/dynamic_symbol_tables.h
@@ -4,6 +4,24 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-CUDNN_PFN_DECL(cudnnCreate, cudnnHandle_t*)
+//===----------------------------------------------------------------------===//
+// Functions required for setting up cuDNN in CuDNNModule.
+//===----------------------------------------------------------------------===//
+
+CUDNN_PFN_DECL(cudnnCreate, cudnnHandle_t *)
 CUDNN_PFN_DECL(cudnnDestroy, cudnnHandle_t)
 CUDNN_PFN_DECL_STR_RETURN(cudnnGetErrorString)
+
+//===----------------------------------------------------------------------===//
+// Functions required for compiling cudnn_frontend (see cudnn_tensor.{h,cpp}).
+//===----------------------------------------------------------------------===//
+
+CUDNN_PFN_DECL(cudnnBackendFinalize, cudnnBackendDescriptor_t)
+CUDNN_PFN_DECL(cudnnBackendSetAttribute, cudnnBackendDescriptor_t,
+               cudnnBackendAttributeName_t, cudnnBackendAttributeType_t,
+               int64_t, const void *)
+CUDNN_PFN_DECL(cudnnBackendCreateDescriptor, cudnnBackendDescriptorType_t,
+               cudnnBackendDescriptor_t *)
+CUDNN_PFN_DECL(cudnnBackendDestroyDescriptor, cudnnBackendDescriptor_t)
+
+CUDNN_PFN_DECL_SIZE_RETURN(cudnnGetVersion);

--- a/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.c
+++ b/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.c
@@ -31,9 +31,24 @@ static iree_status_t openxla_cudnn_dynamic_symbols_resolve_all(
         syms->cudnn_library, kName, (void**)&syms->cuDNNSymbolName)); \
   }
 
+#define CUDNN_PFN_DECL_STR_RETURN(cuDNNSymbolName, ...)               \
+  {                                                                   \
+    static const char* kName = #cuDNNSymbolName;                      \
+    IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(          \
+        syms->cudnn_library, kName, (void**)&syms->cuDNNSymbolName)); \
+  }
+
+#define CUDNN_PFN_DECL_SIZE_RETURN(cuDNNSymbolName, ...)              \
+  {                                                                   \
+    static const char* kName = #cuDNNSymbolName;                      \
+    IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(          \
+        syms->cudnn_library, kName, (void**)&syms->cuDNNSymbolName)); \
+  }
+
 #include "openxla/runtime/nvgpu/dynamic_symbol_tables.h"  // IWYU pragma: export
 
 #undef CUDNN_PFN_DECL
+#undef CUDNN_PFN_DECL_STR_RETURN
   return iree_ok_status();
 }
 

--- a/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.h
+++ b/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.h
@@ -27,10 +27,14 @@ typedef struct openxla_cudnn_dynamic_symbols_t {
   cudnnStatus_t (*cuDNNSymbolName)(__VA_ARGS__);
 #define CUDNN_PFN_DECL_STR_RETURN(cuDNNSymbolName, ...) \
   const char* (*cuDNNSymbolName)(__VA_ARGS__);
+#define CUDNN_PFN_DECL_SIZE_RETURN(cuDNNSymbolName, ...) \
+  size_t (*cuDNNSymbolName)(__VA_ARGS__);
 
 #include "openxla/runtime/nvgpu/dynamic_symbol_tables.h"  // IWYU pragma: export
 
 #undef CUDNN_PFN_DECL
+#undef CUDNN_PFN_DECL_STR_RETURN
+#undef CUDNN_PFN_DECL_SIZE_RETURN
 } openxla_cudnn_dynamic_symbols_t;
 
 // Initializes |out_syms| in-place with dynamically loaded cuDNN symbols.

--- a/runtime/src/openxla/runtime/nvgpu/status_util.h
+++ b/runtime/src/openxla/runtime/nvgpu/status_util.h
@@ -19,7 +19,14 @@ extern "C" {
 // Converts a cudnnStatus_t to an iree_status_t.
 //
 // Usage:
-//   iree_status_t status = CUDNN_STATUS_TO_STATUS(cuDnnDoThing(...));
+//   iree_status_t status = CUDNN_CONVERT_STATUS(syms, cudnn_status);
+#define CUDNN_CONVERT_STATUS(syms, expr, ...) \
+  openxla_cudnn_status_to_status((syms), (expr), __FILE__, __LINE__)
+
+// Converts a cudnnStatus_t to an iree_status_t.
+//
+// Usage:
+//   iree_status_t status = CUDNN_STATUS_TO_STATUS(syms, cuDnnDoThing(...));
 #define CUDNN_STATUS_TO_STATUS(syms, expr, ...) \
   openxla_cudnn_status_to_status((syms), ((syms)->expr), __FILE__, __LINE__)
 
@@ -27,7 +34,7 @@ extern "C" {
 // to a iree_status_t.
 //
 // Usage:
-//   CUDNN_RETURN_IF_ERROR(cuDnnDoThing(...));
+//   CUDNN_RETURN_IF_ERROR(syms, cuDnnDoThing(...));
 #define CUDNN_RETURN_IF_ERROR(syms, expr, ...)                                \
   IREE_RETURN_IF_ERROR(openxla_cudnn_status_to_status((syms), ((syms)->expr), \
                                                       __FILE__, __LINE__),    \
@@ -37,7 +44,7 @@ extern "C" {
 // iree_status_t.
 //
 // Usage:
-//   CUDNN_STATUS_CHECK_OK(cuDnnDoThing(...));
+//   CUDNN_STATUS_CHECK_OK(syms, cuDnnDoThing(...));
 #define CUDNN_STATUS_CHECK_OK(syms, expr, ...)                         \
   IREE_CHECK_OK(openxla_cudnn_status_to_status((syms), ((syms)->expr), \
                                                __FILE__, __LINE__))

--- a/runtime/src/openxla/runtime/nvgpu/test/example.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/example.mlir
@@ -2,11 +2,94 @@
 
 module @example {
 
-  func.func private @cudnn.hello()
+  //===--------------------------------------------------------------------===//
+  // Import functions from the cuDNN module.
+  //===--------------------------------------------------------------------===//
+
+  func.func private @cudnn.tensor.arg(
+    %dtype: i64, %dims: !util.list<i64>, %uid: i64, %alignment: i64
+  ) -> !cudnn.tensor
+
+  func.func private @cudnn.pointwise_relu(
+    %input: !cudnn.tensor, %lower: f32, %upper: f32, %uid: i64, %alignment: i64
+  ) -> !cudnn.tensor
+
+  func.func private @cudnn.graph.create(
+    %tensor: !cudnn.tensor
+  ) -> !cudnn.operation_graph
+
+  func.func private @cudnn.debug.tensor(
+    %tensor: !cudnn.tensor
+  )
+
+  func.func private @cudnn.debug.graph(
+    %graph: !cudnn.operation_graph
+  )
+
+  //===--------------------------------------------------------------------===//
+  // Build and execute cuDNN graph.
+  //===--------------------------------------------------------------------===//
 
   func.func @main() {
-    // CHECK: Hello from OpenXLA CuDNN Module!
-    call @cudnn.hello() : () -> ()
+    %rank = arith.constant 4 : index
+    
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    
+    %c128 = arith.constant 128 : i64
+
+    // Tensor UIDs
+    %uid0 = arith.constant 0 : i64
+    %uid1 = arith.constant 1 : i64
+    
+    // [128, 128, 128, 128]
+    %dims = util.list.create %rank : !util.list<i64>
+    util.list.resize %dims, %rank : !util.list<i64>
+    util.list.set %dims[%c0], %c128 : !util.list<i64>
+    util.list.set %dims[%c1], %c128 : !util.list<i64>
+    util.list.set %dims[%c2], %c128 : !util.list<i64>
+    util.list.set %dims[%c3], %c128 : !util.list<i64>
+
+    // CUDNN_DATA_FLOAT
+    %dtype = arith.constant 0 : i64
+
+    // Tensor alignment
+    %alignment = arith.constant 32 : i64
+
+    // Create !cudnn.tensor<128x128x128x128xf32>
+    %0 = call @cudnn.tensor.arg(%dtype, %dims, %uid0, %alignment)
+           : (i64, !util.list<i64>, i64, i64) -> !cudnn.tensor
+
+    // Create pointwise relu operation
+    %lower = arith.constant 0.0 : f32
+    %upper = arith.constant 9.0 : f32
+    %1 = call @cudnn.pointwise_relu(%0, %lower, %upper, %uid1, %alignment)
+           : (!cudnn.tensor, f32, f32, i64, i64) -> !cudnn.tensor
+
+    // CHECK: CUDNN_BACKEND_TENSOR_DESCRIPTOR : Datatype: CUDNN_DATA_FLOAT
+    // CHECK: Id: 123
+    // CHECK: Alignment: 32
+    // CHECK: nDims 4
+    // CHECK: VectorCount: 1
+    // CHECK: vectorDimension -1
+    // CHECK: Dim [ 128,128,128,128 ]
+    // CHECK: Str [ 2097152,16384,128,1 ]
+    // CHECK: isVirtual: 0
+    // CHECK: isByValue: 0
+    // CHECK: reorder_type: CUDNN_TENSOR_REORDERING_NONE
+    call @cudnn.debug.tensor(%0) : (!cudnn.tensor) -> ()
+    call @cudnn.debug.tensor(%1) : (!cudnn.tensor) -> ()
+
+    // Create an operation graph computing pointwise relu.
+    %2 = call @cudnn.graph.create(%1)
+           : (!cudnn.tensor) -> !cudnn.operation_graph
+
+    // CHECK: Graph: CUDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR has 1operations
+    // CHECK: Tag: ReluFwd_
+    call @cudnn.debug.graph(%2) : (!cudnn.operation_graph) -> ()
+
     return
   }
 

--- a/tools/openxla-runner.c
+++ b/tools/openxla-runner.c
@@ -38,6 +38,10 @@ int main(int argc, char** argv) {
   IREE_CHECK_OK(iree_runtime_instance_create(&instance_options, host_allocator,
                                              &instance));
 
+  // Register custom types define by cuDNN module.
+  IREE_CHECK_OK(iree_custom_module_cudnn_register_types(
+      iree_runtime_instance_vm_instance(instance)));
+
   // Try to create the CUDA device.
   iree_hal_device_t* device = NULL;
   IREE_CHECK_OK(iree_runtime_instance_try_create_default_device(


### PR DESCRIPTION
Initial support for constructing cuDNN graphs:

1. `@cudnn.tensor.arg` - creates tensor arguments
2. `@cudnn.pointwise_relu` - creates Relu operation
3. `@cudnn.create.graph` - creates an operation graph

Adds `cudnn_frontend` as a dependency.