### PR TITLE
[cuDNN] Add e2e test for Conv2D + BatchNorm

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.td
@@ -242,6 +242,31 @@ def CUDNN_ConvolutionOp : CUDNN_Op<"convolution", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// cudnn.batch_norm_inference operation
+//===----------------------------------------------------------------------===//
+
+def CUDNN_BatchNormInferenceOp : CUDNN_Op<"batch_norm_inference", [Pure]> {
+    let summary = "Batch normalization in inference phase";
+
+    let arguments = (ins
+      CUDNN_TensorType:$x,
+      CUDNN_TensorType:$scale,
+      CUDNN_TensorType:$offset,
+      CUDNN_TensorType:$mean,
+      CUDNN_TensorType:$variance,
+      CUDNN_TensorType:$epsilon
+    );
+
+    let results = (outs CUDNN_TensorType:$y);
+
+    let assemblyFormat = [{
+      `(` $x `,` $scale `,` $offset `,` $mean `,` $variance `,` $epsilon`)`
+         attr-dict `:`
+         functional-type(operands, results)
+    }];
+}
+
+//===----------------------------------------------------------------------===//
 // cudnn.graph operation
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/test/ops.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/test/ops.mlir
@@ -93,6 +93,26 @@ cudnn.graph @convolution(
 
 // -----
 
+cudnn.graph @batch_norm_inference(
+  %x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
+  %vec: !cudnn.tensor<1x32x1x1xf32, NHWC>,
+  %scalar: !cudnn.tensor<1x1x1x1xf32, NHWC>
+) -> !cudnn.tensor<8x32x4x4xf32, NHWC> {
+  %0 = cudnn.batch_norm_inference(%x, %vec, %vec, %vec, %vec, %scalar)
+    : (!cudnn.tensor<8x32x4x4xf32, NHWC>, !cudnn.tensor<1x32x1x1xf32, NHWC>,
+       !cudnn.tensor<1x32x1x1xf32, NHWC>, !cudnn.tensor<1x32x1x1xf32, NHWC>,
+       !cudnn.tensor<1x32x1x1xf32, NHWC>, !cudnn.tensor<1x1x1x1xf32, NHWC>)
+    -> !cudnn.tensor<8x32x4x4xf32, NHWC>
+  cudnn.return %0: !cudnn.tensor<8x32x4x4xf32, NHWC>
+}
+
+// CHECK: cudnn.graph @batch_norm_inference
+// CHECK: {
+// CHECK:   cudnn.batch_norm_inference
+// CHECK: }
+
+// -----
+
 cudnn.graph @sqrt(%x: !cudnn.tensor<8x4x4xf32>) -> !cudnn.tensor<8x4x4xf32> {
   %0 = cudnn.sqrt(%x) : (!cudnn.tensor<8x4x4xf32>) -> !cudnn.tensor<8x4x4xf32>
   cudnn.return %0: !cudnn.tensor<8x4x4xf32>

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/BUILD.bazel
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/BUILD.bazel
@@ -47,6 +47,7 @@ cc_library(
     name = "Transforms",
     srcs = [
         "ConvertCUDNNToRuntime.cpp",
+        "ExpandCUDNNOperations.cpp",
     ],
     hdrs = ["Passes.h"],
     deps = [

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/CMakeLists.txt
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "Passes.h"
   SRCS
     "ConvertCUDNNToRuntime.cpp"
+    "ExpandCUDNNOperations.cpp"
   DEPS
     ::PassHeaders
     MLIRPass

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/ExpandCUDNNOperations.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/ExpandCUDNNOperations.cpp
@@ -1,0 +1,88 @@
+// Copyright 2023 The OpenXLA Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNDialect.h>
+#include <openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.h>
+#include <openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNTypes.h>
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/PassDetail.h"
+#include "openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/Passes.h"
+
+#define GEN_PASS_DEF_EXPANDCUDNNOPERATIONS
+#include "openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/Passes.h.inc"
+
+namespace IREE = mlir::iree_compiler::IREE;
+
+using namespace mlir;
+
+namespace openxla::compiler::nvgpu::cudnn {
+
+namespace {
+
+struct ExpandBatchNormInferenceOp
+    : public OpRewritePattern<BatchNormInferenceOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(BatchNormInferenceOp op,
+                                PatternRewriter &rewriter) const final {
+    ImplicitLocOpBuilder b(op.getLoc(), rewriter);
+
+    Value x = op.getX();
+    Value scale = op.getScale();
+    Value offset = op.getOffset();
+    Value mean = op.getMean();
+    Value var = op.getVariance();
+    Value eps = op.getEpsilon();
+
+    auto tensor = x.getType();
+    auto vector = var.getType();
+
+    // Use batch norm inference expansion defined by StableHLO:
+    // https://github.com/openxla/stablehlo/blob/main/docs/spec.md#batch_norm_inference
+
+    Value centered = b.create<SubOp>(tensor, ValueRange({x, mean}));
+    Value stddev = b.create<SqrtOp>(
+        tensor, Value(b.create<AddOp>(vector, ValueRange({var, eps}))));
+    Value normalized = b.create<DivOp>(tensor, ValueRange({centered, stddev}));
+    Value scaled = b.create<MulOp>(tensor, ValueRange({normalized, scale}));
+    Value shifted = b.create<AddOp>(tensor, ValueRange({scaled, offset}));
+
+    rewriter.replaceOp(op, shifted);
+    return success();
+  }
+};
+
+}  // namespace
+
+class ExpandCudnnOperations
+    : public ::impl::ExpandCudnnOperationsBase<ExpandCudnnOperations> {
+ public:
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    ConversionTarget target(getContext());
+
+    patterns.insert<ExpandBatchNormInferenceOp>(patterns.getContext());
+
+    target.addLegalDialect<CUDNNDialect>();
+    // TODO(ezhulenev): Operation legality should be defined by the cuDNN graph
+    // itself, batch norm itself can be a "root" of the cuDNN graph with
+    // pointwise fusion into it.
+    target.addIllegalOp<BatchNormInferenceOp>();
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createExpandCudnnOperationsPass() {
+  return std::make_unique<ExpandCudnnOperations>();
+}
+
+}  // namespace openxla::compiler::nvgpu::cudnn

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/Passes.h
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/Passes.h
@@ -14,6 +14,13 @@
 namespace openxla::compiler::nvgpu::cudnn {
 
 //===----------------------------------------------------------------------===//
+// Transformations on cuDNN dialect
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+createExpandCudnnOperationsPass();
+
+//===----------------------------------------------------------------------===//
 // Conversion from cuDNN dialect
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/Passes.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/Passes.td
@@ -9,6 +9,29 @@ include "mlir/Pass/PassBase.td"
 #ifndef OPENXLA_COMPILER_NVGPU_DIALECT_CUDNN_TRANSFORMS_PASSES_TD_
 #define OPENXLA_COMPILER_NVGPU_DIALECT_CUDNN_TRANSFORMS_PASSES_TD_
 
+def ExpandCudnnOperations :
+    Pass<"openxla-nvgpu-expand-cudnn-operations", "mlir::ModuleOp"> {
+  let summary = "Expands cuDNN operations to primitive cuDNN operations";
+
+  let description = [{
+    Some cuDNN operations are not supported by the cuDNN runtime fusion engine,
+    however they can be expanded into a sequence of primitive operations, that
+    could be compiled by cuDNN at runtime.
+
+    For example batch normalization is not supported as a convolution epilogue,
+    however at inference phase it can be expanded into a sequence of pointwise
+    operations that can be fused into the preceeding convolution.
+  }];
+
+  let constructor = [{
+    ::openxla::compiler::nvgpu::cudnn::createExpandCudnnOperationsPass()
+  }];
+
+  let dependentDialects = [
+    "::openxla::compiler::nvgpu::cudnn::CUDNNDialect",
+  ];
+}
+
 def ConvertCudnnToRuntime :
     Pass<"openxla-nvgpu-convert-cudnn-to-runtime", "mlir::ModuleOp"> {
   let summary = "Converts cuDNN operations to cuDNN runtime calls";

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/test/expand_batch_norm.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/test/expand_batch_norm.mlir
@@ -1,0 +1,36 @@
+// RUN: iree-opt %s --iree-plugin=openxla_nvgpu --split-input-file \
+// RUN:   --pass-pipeline='builtin.module(openxla-nvgpu-expand-cudnn-operations)' \
+// RUN:   | FileCheck %s
+
+cudnn.graph @batch_norm_inference(
+  %x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
+  %scale: !cudnn.tensor<1x32x1x1xf32, NHWC> {cudnn.scale},
+  %offset: !cudnn.tensor<1x32x1x1xf32, NHWC> {cudnn.offset},
+  %mean: !cudnn.tensor<1x32x1x1xf32, NHWC> {cudnn.mean},
+  %var: !cudnn.tensor<1x32x1x1xf32, NHWC> {cudnn.var},
+  %epsilon: !cudnn.tensor<1x1x1x1xf32, NHWC>
+) -> !cudnn.tensor<8x32x4x4xf32, NHWC> {
+  %0 = cudnn.batch_norm_inference(%x, %scale, %offset, %mean, %var, %epsilon)
+    : (!cudnn.tensor<8x32x4x4xf32, NHWC>, !cudnn.tensor<1x32x1x1xf32, NHWC>,
+       !cudnn.tensor<1x32x1x1xf32, NHWC>, !cudnn.tensor<1x32x1x1xf32, NHWC>,
+       !cudnn.tensor<1x32x1x1xf32, NHWC>, !cudnn.tensor<1x1x1x1xf32, NHWC>)
+    -> !cudnn.tensor<8x32x4x4xf32, NHWC>
+  cudnn.return %0: !cudnn.tensor<8x32x4x4xf32, NHWC>
+}
+
+// CHECK: cudnn.graph @batch_norm_inference(
+// CHECK:   %[[X:.*]]: !cudnn.tensor<8x32x4x4xf32, NHWC>,
+// CHECK:   %[[SCALE:.*]]: !cudnn.tensor<1x32x1x1xf32, NHWC> {cudnn.scale}
+// CHECK:   %[[OFFSET:.*]]: !cudnn.tensor<1x32x1x1xf32, NHWC> {cudnn.offset}
+// CHECK:   %[[MEAN:.*]]: !cudnn.tensor<1x32x1x1xf32, NHWC> {cudnn.mean}
+// CHECK:   %[[VAR:.*]]: !cudnn.tensor<1x32x1x1xf32, NHWC> {cudnn.var}
+// CHECK:   %[[EPSILON:.*]]: !cudnn.tensor<1x1x1x1xf32, NHWC>
+// CHECK: ) -> !cudnn.tensor<8x32x4x4xf32, NHWC> {
+// CHECK:   %[[CENTERED:.*]] = cudnn.sub(%[[X]], %[[MEAN]])
+// CHECK:   %[[ADD:.*]] = cudnn.add(%[[VAR]], %[[EPSILON]])
+// CHECK:   %[[STDDEV:.*]] = cudnn.sqrt(%[[ADD]])
+// CHECK:   %[[NORMALIZED:.*]] = cudnn.div(%[[CENTERED]], %[[STDDEV]])
+// CHECK:   %[[SCALED:.*]] = cudnn.mul(%[[NORMALIZED]], %[[SCALE]])
+// CHECK:   %[[SHIFTED:.*]] = cudnn.add(%[[SCALED]], %[[OFFSET]])
+// CHECK:   cudnn.return %[[SHIFTED]]
+// CHECK: }

--- a/compiler/src/openxla/compiler/nvgpu/PluginRegistration.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/PluginRegistration.cpp
@@ -55,6 +55,7 @@ struct NvgpuSession : public PluginSession<NvgpuSession, NvgpuOptions> {
   }
 
   void extendPreprocessingPassPipeline(OpPassManager &pm) override {
+    pm.addPass(cudnn::createExpandCudnnOperationsPass());
     pm.addPass(cudnn::createConvertCudnnToRuntimePass());
   }
 };

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm.mlir
@@ -1,0 +1,55 @@
+module @example {
+
+cudnn.graph @conv2d(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
+                    %w: !cudnn.tensor<32x32x1x1xf32, NHWC>,
+                    %scale: !cudnn.tensor<1x32x1x1xf32, NHWC>,
+                    %offset: !cudnn.tensor<1x32x1x1xf32, NHWC>,
+                    %mean: !cudnn.tensor<1x32x1x1xf32, NHWC>,
+                    %var: !cudnn.tensor<1x32x1x1xf32, NHWC>,
+                    %epsilon: !cudnn.tensor<1x1x1x1xf32, NHWC>
+  ) -> !cudnn.tensor<8x32x4x4xf32, NHWC> {
+  %0 = cudnn.convolution(%x, %w) alpha=1.0 beta=0.0
+         spatial_dim_count=2
+         spatial_stride=[1,1]
+         pre_padding=[0,0]
+         post_padding=[0,0]
+         dilation=[1,1]
+    : (!cudnn.tensor<8x32x4x4xf32, NHWC>, !cudnn.tensor<32x32x1x1xf32, NHWC>)
+    -> !cudnn.tensor<8x32x4x4xf32, NHWC>
+
+  %1 = cudnn.batch_norm_inference(%0, %scale, %offset, %mean, %var, %epsilon)
+      : (!cudnn.tensor<8x32x4x4xf32, NHWC>, !cudnn.tensor<1x32x1x1xf32, NHWC>,
+         !cudnn.tensor<1x32x1x1xf32, NHWC>, !cudnn.tensor<1x32x1x1xf32, NHWC>,
+         !cudnn.tensor<1x32x1x1xf32, NHWC>, !cudnn.tensor<1x1x1x1xf32, NHWC>)
+      -> !cudnn.tensor<8x32x4x4xf32, NHWC>
+
+  cudnn.return %1: !cudnn.tensor<8x32x4x4xf32, NHWC>
+}
+
+util.global @x : tensor<8x4x4x32xf32> = dense<1.0> : tensor<8x4x4x32xf32>
+util.global @w : tensor<32x1x1x32xf32> = dense<1.0> : tensor<32x1x1x32xf32>
+util.global @scale : tensor<1x1x1x32xf32> = dense<0.5> : tensor<1x1x1x32xf32>
+util.global @offset : tensor<1x1x1x32xf32> = dense<1.0> : tensor<1x1x1x32xf32>
+util.global @mean : tensor<1x1x1x32xf32> = dense<0.25> : tensor<1x1x1x32xf32>
+util.global @variance : tensor<1x1x1x32xf32> = dense<0.2> : tensor<1x1x1x32xf32>
+util.global @epsilon : tensor<1x1x1x1xf32> = dense<0.0001> : tensor<1x1x1x1xf32>
+
+func.func @main() -> tensor<8x4x4x32xf32> {
+  %x = util.global.load @x : tensor<8x4x4x32xf32>
+  %w = util.global.load @w : tensor<32x1x1x32xf32>
+  %scale = util.global.load @scale : tensor<1x1x1x32xf32>
+  %offset = util.global.load @offset : tensor<1x1x1x32xf32>
+  %mean = util.global.load @mean : tensor<1x1x1x32xf32>
+  %variance = util.global.load @variance : tensor<1x1x1x32xf32>
+  %epsilon = util.global.load @epsilon : tensor<1x1x1x1xf32>
+
+  %0 = cudnn.call @conv2d(%x, %w, %scale, %offset, %mean, %variance, %epsilon)
+       : (tensor<8x4x4x32xf32>, tensor<32x1x1x32xf32>, tensor<1x1x1x32xf32>,
+          tensor<1x1x1x32xf32>, tensor<1x1x1x32xf32>, tensor<1x1x1x32xf32>,
+          tensor<1x1x1x1xf32>)
+       -> tensor<8x4x4x32xf32>
+
+  return %0 : tensor<8x4x4x32xf32>
+}
+
+}


### PR DESCRIPTION
Add an `openxla-nvgpu-expand-cudnn-operations` pass for expanding batch norm into pointwise operations, that later could be fused with convolution using cuDNN runtime fusion engine