### PR TITLE
[cuDNN] Add explicit cudnn handle argument to cudnn call op

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/BUILD.bazel
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/BUILD.bazel
@@ -53,6 +53,7 @@ cc_library(
         ":CUDNNOpsGen",
         ":CUDNNTypesGen",
         "//compiler/src/openxla/compiler/nvgpu:defs",
+        "@iree_core//compiler/src/iree/compiler/Dialect/HAL/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
@@ -63,11 +64,17 @@ iree_gentbl_cc_library(
     name = "CUDNNOpsGen",
     tbl_outs = [
         (
-            ["--gen-dialect-decls"],
+            [
+                "--gen-dialect-decls",
+                "--dialect=cudnn",
+            ],
             "CUDNNOpsDialect.h.inc",
         ),
         (
-            ["--gen-dialect-defs"],
+            [
+                "--gen-dialect-defs",
+                "--dialect=cudnn",
+            ],
             "CUDNNOpsDialect.cpp.inc",
         ),
         (

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CMakeLists.txt
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_library(
     LLVMSupport
     MLIRIR
     MLIRSupport
+    iree::compiler::Dialect::HAL::IR
     openxla::compiler::nvgpu::defs
   PUBLIC
 )
@@ -46,8 +47,8 @@ iree_tablegen_library(
   TD_FILE
     "CUDNNOps.td"
   OUTS
-    --gen-dialect-decls CUDNNDialect.h.inc
-    --gen-dialect-defs CUDNNDialect.cpp.inc
+    --gen-dialect-decls --dialect=cudnn CUDNNDialect.h.inc
+    --gen-dialect-defs --dialect=cudnn CUDNNDialect.cpp.inc
     --gen-op-decls CUDNNOps.h.inc
     --gen-op-defs CUDNNOps.cpp.inc
 )

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.cpp
@@ -23,6 +23,7 @@
 namespace openxla::compiler::nvgpu::cudnn {
 
 using namespace mlir;
+using namespace mlir::iree_compiler;
 
 //===----------------------------------------------------------------------===//
 // cudnn.graph operation
@@ -109,9 +110,9 @@ static LogicalResult verifyTensorTypes(Diagnostic emitOpError,
                                        std::string_view kind,
                                        unsigned ordinal) {
   if (!cudnnType)
-    return emitOpError() << "unsupported graph " << kind << "#" << ordinal;
+    return emitOpError() << "unsupported graph " << kind << " #" << ordinal;
   if (!tensorType)
-    return emitOpError() << "unsupported " << kind << "#" << ordinal;
+    return emitOpError() << "unsupported " << kind << " #" << ordinal;
 
   if (cudnnType.getElementType() != tensorType.getElementType())
     return emitOpError() << kind << "#" << ordinal
@@ -157,14 +158,14 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   for (unsigned i = 0; i < graphArgs.size(); ++i) {
     auto cudnnArg = graphArgs[i].dyn_cast<cudnn::TensorType>();
-    auto tensorArg = getOperandTypes()[i].dyn_cast<RankedTensorType>();
+    auto tensorArg = getArguments()[i].getType().dyn_cast<RankedTensorType>();
     if (failed(verifyTensorTypes(emitErr, cudnnArg, tensorArg, "argument", i)))
       return failure();
   }
 
   for (unsigned i = 0; i < graphResults.size(); ++i) {
     auto cudnnRet = graphResults[i].dyn_cast<cudnn::TensorType>();
-    auto tensorRet = getResultTypes()[i].dyn_cast<RankedTensorType>();
+    auto tensorRet = getResults()[i].getType().dyn_cast<RankedTensorType>();
     if (failed(verifyTensorTypes(emitErr, cudnnRet, tensorRet, "result", i)))
       return failure();
   }

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.h
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.h
@@ -9,6 +9,7 @@
 #ifndef CUDNN_CUDNNOPS_H
 #define CUDNN_CUDNNOPS_H
 
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/FunctionInterfaces.h"

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.td
@@ -9,6 +9,7 @@
 #ifndef CUDNN_OPS
 #define CUDNN_OPS
 
+include "iree/compiler/Dialect/HAL/IR/HALBase.td"
 include "openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNDialect.td"
 include "openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNTypes.td"
 include "mlir/IR/OpBase.td"
@@ -313,6 +314,33 @@ def CUDNN_ReturnOp : CUDNN_Op<"return", [
 }
 
 //===----------------------------------------------------------------------===//
+// cudnn.handle operation
+//===----------------------------------------------------------------------===//
+
+def CUDNN_HandleOp : CUDNN_Op<"handle", [Pure]> {
+  let summary = "Returns a cuDNN handle for the given device";
+
+  let arguments = (ins
+    HAL_Device:$device
+  );
+
+  let results = (outs
+    CUDNN_HandleType:$result
+  );
+
+  let assemblyFormat = [{
+    `(` $device `)` attr-dict `:` type($result)
+  }];
+
+  let builders = [
+    OpBuilder<(ins),
+    [{
+      $_state.addTypes({HandleType::get($_builder.getContext())});
+    }]>,
+  ];
+}
+
+//===----------------------------------------------------------------------===//
 // cudnn.call operation
 //===----------------------------------------------------------------------===//
 
@@ -323,11 +351,12 @@ def CUDNN_CallOp : CUDNN_Op<"call", [
   let summary = "cuDNN call operation";
 
   let description = [{
-    Calls a cuDNN graph with the given arguments.
+    Calls a cuDNN graph with the given cuDNN handle and arguments.
   }];
 
   let arguments = (ins
     CUDNN_GraphRefAttr:$callee,
+    CUDNN_HandleType:$handle,
     Variadic<AnyRankedTensor>:$arguments
   );
 
@@ -336,7 +365,9 @@ def CUDNN_CallOp : CUDNN_Op<"call", [
   );
 
   let assemblyFormat = [{
-    $callee `(` operands `)` attr-dict `:` functional-type(operands, results)
+    `handle` `(` $handle `)` $callee `(` $arguments `)`
+       attr-dict `:`
+       functional-type($arguments, $results)
   }];
 
   let extraClassDeclaration = [{

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/test/ops.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/test/ops.mlir
@@ -2,13 +2,26 @@
 // RUN:   | iree-opt --iree-plugin=openxla_nvgpu --split-input-file \
 // RUN:   | FileCheck %s
 
+func.func @main(%arg0: !hal.device) -> !cudnn.handle {
+  %0 = cudnn.handle(%arg0) : !cudnn.handle
+  return %0 : !cudnn.handle
+}
+
+// CHECK: func @main(%[[ARG0:.*]]: !hal.device) -> !cudnn.handle {
+// CHECK:   cudnn.handle(%[[ARG0]]) : !cudnn.handle
+// CHECK: }
+
+// -----
+
 cudnn.graph @graph(%arg0: !cudnn.tensor<1x4x8xf32>)
-                     -> !cudnn.tensor<1x4x8xf32> {
+                       -> !cudnn.tensor<1x4x8xf32> {
   cudnn.return %arg0: !cudnn.tensor<1x4x8xf32>
 }
 
-func.func @main(%arg0: tensor<1x4x8xf32>) -> tensor<1x4x8xf32> {
-  %0 = cudnn.call @graph(%arg0) : (tensor<1x4x8xf32>) -> tensor<1x4x8xf32>
+func.func @main(%arg0: !cudnn.handle,
+                %arg1: tensor<1x4x8xf32>) -> tensor<1x4x8xf32> {
+  %0 = cudnn.call handle(%arg0) @graph(%arg1)
+       : (tensor<1x4x8xf32>) -> tensor<1x4x8xf32>
   return %0 : tensor<1x4x8xf32>
 }
 
@@ -19,8 +32,10 @@ cudnn.graph @graph(%arg0: !cudnn.tensor<1x32x4x4xf32, NHWC>)
   cudnn.return %arg0: !cudnn.tensor<1x32x4x4xf32, NHWC>
 }
 
-func.func @main(%arg0: tensor<1x4x4x32xf32>) -> tensor<1x4x4x32xf32> {
-  %0 = cudnn.call @graph(%arg0) : (tensor<1x4x4x32xf32>) -> tensor<1x4x4x32xf32>
+func.func @main(%arg0: !cudnn.handle,
+                %arg1: tensor<1x4x4x32xf32>) -> tensor<1x4x4x32xf32> {
+  %0 = cudnn.call handle(%arg0) @graph(%arg1)
+       : (tensor<1x4x4x32xf32>) -> tensor<1x4x4x32xf32>
   return %0 : tensor<1x4x4x32xf32>
 }
 
@@ -33,8 +48,10 @@ cudnn.graph @graph(%arg0: !cudnn.tensor<1x32x4x4xf32, #NHWC>)
   cudnn.return %arg0: !cudnn.tensor<1x32x4x4xf32, #NHWC>
 }
 
-func.func @main(%arg0: tensor<1x4x4x32xf32>) -> tensor<1x4x4x32xf32> {
-  %0 = cudnn.call @graph(%arg0) : (tensor<1x4x4x32xf32>) -> tensor<1x4x4x32xf32>
+func.func @main(%arg0: !cudnn.handle,
+                %arg1: tensor<1x4x4x32xf32>) -> tensor<1x4x4x32xf32> {
+  %0 = cudnn.call handle(%arg0) @graph(%arg1)
+       : (tensor<1x4x4x32xf32>) -> tensor<1x4x4x32xf32>
   return %0 : tensor<1x4x4x32xf32>
 }
 

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/test/cudnn_to_runtime.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/Transforms/test/cudnn_to_runtime.mlir
@@ -7,18 +7,19 @@ cudnn.graph @graph(%arg0: !cudnn.tensor<1x4x8xf32>)
   cudnn.return %arg0: !cudnn.tensor<1x4x8xf32>
 }
 
-// CHECK: func.func @graph.builder() -> !cudnn.operation_graph {
+// CHECK: func @graph.builder(%[[HANDLE:.*]]: !cudnn.handle)
+// CHECK:   -> !cudnn.operation_graph {
 // CHECK:   %[[DT:.*]] = arith.constant 0 : i64
 // CHECK:   %[[D0:.*]] = arith.constant 1 : i64
 // CHECK:   %[[D1:.*]] = arith.constant 4 : i64
 // CHECK:   %[[D2:.*]] = arith.constant 8 : i64
 // CHECK:   %[[ARG:.*]] = call @cudnn.tensor.create.3d(%[[DT]], %[[D0]], %[[D1]], %[[D2]])
-// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[ARG]])
+// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[HANDLE]], %[[ARG]])
 // CHECK:   return %[[GRAPH]] : !cudnn.operation_graph
 // CHECK: }
 
 // CHECK: @cudnn.tensor.create.3d(i64, i64, i64, i64) -> !cudnn.tensor
-// CHECK: @cudnn.operation_graph.create(!cudnn.tensor) -> !cudnn.operation_graph
+// CHECK: @cudnn.operation_graph.create(!cudnn.handle, !cudnn.tensor) -> !cudnn.operation_graph
 
 // -----
 
@@ -27,7 +28,7 @@ cudnn.graph @graph(%arg0: !cudnn.tensor<1x4x8xi32>)
   cudnn.return %arg0: !cudnn.tensor<1x4x8xi32>
 }
 
-// CHECK: func.func @graph.builder() -> !cudnn.operation_graph {
+// CHECK: func @graph.builder({{.*}}: !cudnn.handle) -> !cudnn.operation_graph {
 // CHECK:   %[[DT:.*]] = arith.constant 4 : i64
 // CHECK:   call @cudnn.tensor.create.3d(%[[DT]],
 // CHECK: }
@@ -39,7 +40,7 @@ cudnn.graph @graph(%arg0: !cudnn.tensor<1x4x4x32xi32, NHWC>)
   cudnn.return %arg0: !cudnn.tensor<1x4x4x32xi32, NHWC>
 }
 
-// CHECK: func.func @graph.builder() -> !cudnn.operation_graph {
+// CHECK: func @graph.builder({{.*}}: !cudnn.handle) -> !cudnn.operation_graph {
 // CHECK:   call @cudnn.tensor.create.4d.nhwc
 // CHECK: }
 
@@ -51,18 +52,17 @@ cudnn.graph @sqrt(%x: !cudnn.tensor<8x4x4xf32>) -> !cudnn.tensor<8x4x4xf32> {
   cudnn.return %0: !cudnn.tensor<8x4x4xf32>
 }
 
-// CHECK: func.func @sqrt.builder() -> !cudnn.operation_graph {
+// CHECK: func @sqrt.builder(%[[HANDLE:.*]]: !cudnn.handle) -> !cudnn.operation_graph {
 // CHECK:   %[[X:.*]] = call @cudnn.tensor.create.3d
 // CHECK:   %[[ALPHA:.*]] = arith.constant 5.000000e-01 : f32
 // CHECK:   %[[VIRTUAL:.*]] = arith.constant 0 : i32
 // CHECK:   %[[Y:.*]] = call @cudnn.sqrt(%[[X]], %[[ALPHA]], %[[VIRTUAL]])
-// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[Y]])
+// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[HANDLE]], %[[Y]])
 // CHECK:   return %[[GRAPH]] : !cudnn.operation_graph
 // CHECK: }
 
 // CHECK: @cudnn.tensor.create.3d(i64, i64, i64, i64) -> !cudnn.tensor
 // CHECK: @cudnn.sqrt(!cudnn.tensor, f32, i32) -> !cudnn.tensor
-// CHECK: @cudnn.operation_graph.create(!cudnn.tensor) -> !cudnn.operation_graph
 
 // -----
 
@@ -74,7 +74,7 @@ cudnn.graph @add(%x: !cudnn.tensor<8x4x4xf32>, %b: !cudnn.tensor<8x4x4xf32>)
   cudnn.return %0: !cudnn.tensor<8x4x4xf32>
 }
 
-// CHECK: func.func @add.builder() -> !cudnn.operation_graph {
+// CHECK: func @add.builder(%[[HANDLE:.*]]: !cudnn.handle) -> !cudnn.operation_graph {
 // CHECK:   %[[X:.*]] = call @cudnn.tensor.create.3d
 // CHECK:   %[[B:.*]] = call @cudnn.tensor.create.3d
 // CHECK:   %[[ALPHA:.*]] = arith.constant 1.000000e+00 : f32
@@ -82,13 +82,12 @@ cudnn.graph @add(%x: !cudnn.tensor<8x4x4xf32>, %b: !cudnn.tensor<8x4x4xf32>)
 // CHECK:   %[[VIRTUAL:.*]] = arith.constant 0 : i32
 // CHECK:   %[[Y:.*]] = call @cudnn.add(%[[X]], %[[ALPHA]], %[[B]],
 // CHECK:                               %[[ALPHA2]], %[[VIRTUAL]])
-// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[Y]])
+// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[HANDLE]], %[[Y]])
 // CHECK:   return %[[GRAPH]] : !cudnn.operation_graph
 // CHECK: }
 
 // CHECK: @cudnn.tensor.create.3d(i64, i64, i64, i64) -> !cudnn.tensor
 // CHECK: @cudnn.add(!cudnn.tensor, f32, !cudnn.tensor, f32, i32) -> !cudnn.tensor
-// CHECK: @cudnn.operation_graph.create(!cudnn.tensor) -> !cudnn.operation_graph
 
 // -----
 
@@ -98,7 +97,7 @@ cudnn.graph @div(%x: !cudnn.tensor<8x4x4xf32>) -> !cudnn.tensor<8x4x4xf32> {
   cudnn.return %0: !cudnn.tensor<8x4x4xf32>
 }
 
-// CHECK: func.func @div.builder() -> !cudnn.operation_graph {
+// CHECK: func @div.builder(%[[HANDLE:.*]]: !cudnn.handle) -> !cudnn.operation_graph {
 // CHECK:   %[[ALPHA:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:   %[[ALPHA2:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:   call @cudnn.div
@@ -114,7 +113,7 @@ cudnn.graph @max(%x: !cudnn.tensor<8x4x4xf32>) -> !cudnn.tensor<8x4x4xf32> {
   cudnn.return %0: !cudnn.tensor<8x4x4xf32>
 }
 
-// CHECK: func.func @max.builder() -> !cudnn.operation_graph {
+// CHECK: func @max.builder(%[[HANDLE:.*]]: !cudnn.handle) -> !cudnn.operation_graph {
 // CHECK:   %[[ALPHA:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:   %[[ALPHA2:.*]] = arith.constant 1.000000e+00 : f32
 // CHECK:   call @cudnn.max
@@ -134,18 +133,17 @@ cudnn.graph @bias(
   cudnn.return %0: !cudnn.tensor<8x32x4x4xf32, NHWC>
 }
 
-// CHECK: func.func @bias.builder() -> !cudnn.operation_graph {
+// CHECK: func @bias.builder(%[[HANDLE:.*]]: !cudnn.handle) -> !cudnn.operation_graph {
 // CHECK:   %[[X:.*]] = call @cudnn.tensor.create.4d.nhwc
 // CHECK:   %[[B:.*]] = call @cudnn.tensor.create.4d.nhwc
 // CHECK:   %[[VIRTUAL:.*]] = arith.constant 0 : i32
 // CHECK:   %[[Y:.*]] = call @cudnn.bias(%[[X]], %[[B]], %[[VIRTUAL]])
-// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[Y]])
+// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[HANDLE]], %[[Y]])
 // CHECK:   return %[[GRAPH]] : !cudnn.operation_graph
 // CHECK: }
 
 // CHECK: @cudnn.tensor.create.4d.nhwc(i64, i64, i64, i64, i64) -> !cudnn.tensor
 // CHECK: @cudnn.bias(!cudnn.tensor, !cudnn.tensor, i32) -> !cudnn.tensor
-// CHECK: @cudnn.operation_graph.create(!cudnn.tensor) -> !cudnn.operation_graph
 
 // -----
 
@@ -164,21 +162,20 @@ cudnn.graph @convolution(
   cudnn.return %0: !cudnn.tensor<8x32x4x4xf32, NHWC>
 }
 
-// CHECK: func.func @convolution.builder() -> !cudnn.operation_graph {
+// CHECK: func @convolution.builder(%[[HANDLE:.*]]: !cudnn.handle) -> !cudnn.operation_graph {
 // CHECK:   %[[X:.*]] = call @cudnn.tensor.create.4d.nhwc
 // CHECK:   %[[W:.*]] = call @cudnn.tensor.create.4d.nhwc
 // CHECK:   %[[VIRTUAL:.*]] = arith.constant 0 : i32
 // CHECK:   %[[MODE:.*]] = arith.constant 1 : i32
 // CHECK:   %[[Y:.*]] = call @cudnn.convolution.2d(%[[X]], %[[W]],
 // CHECK:                                         %[[VIRTUAL]], %[[MODE]])
-// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[Y]])
+// CHECK:   %[[GRAPH:.*]] = call @cudnn.operation_graph.create(%[[HANDLE]], %[[Y]])
 // CHECK:   return %[[GRAPH]] : !cudnn.operation_graph
 // CHECK: }
 
 // CHECK: @cudnn.tensor.create.4d.nhwc(i64, i64, i64, i64, i64) -> !cudnn.tensor
 // CHECK: @cudnn.convolution.2d(!cudnn.tensor, !cudnn.tensor, i64, i64, i64,
 // CHECK-SAME:                  i64, i64, i64, i64, i64, i32, i32)
-// CHECK: @cudnn.operation_graph.create(!cudnn.tensor) -> !cudnn.operation_graph
 
 // -----
 
@@ -186,15 +183,18 @@ cudnn.graph @graph(%arg: !cudnn.tensor<1x4x8xf32>) -> !cudnn.tensor<1x4x8xf32> {
   cudnn.return %arg: !cudnn.tensor<1x4x8xf32>
 }
 
-func.func @main(%arg: tensor<1x4x8xf32>) -> tensor<1x4x8xf32> {
-  %0 = cudnn.call @graph(%arg) : (tensor<1x4x8xf32>) -> tensor<1x4x8xf32>
+func.func @main(%handle: !cudnn.handle,
+                %arg: tensor<1x4x8xf32>) -> tensor<1x4x8xf32> {
+  %0 = cudnn.call handle(%handle) @graph(%arg)
+       : (tensor<1x4x8xf32>) -> tensor<1x4x8xf32>
   return %0 : tensor<1x4x8xf32>
 }
 
-// CHECK: func.func @graph.builder() -> !cudnn.operation_graph
+// CHECK: func @graph.builder({{.*}}: !cudnn.handle) -> !cudnn.operation_graph
 
-// CHECK: func.func @main(%[[ARG:.*]]: tensor<1x4x8xf32>) -> tensor<1x4x8xf32> {
-// CHECK:   %[[G:.*]] = call @graph.builder()
+// CHECK: func.func @main(%[[HANDLE:.*]]: !cudnn.handle,
+// CHECK:                 %[[ARG:.*]]: tensor<1x4x8xf32>) -> tensor<1x4x8xf32> {
+// CHECK:   %[[G:.*]] = call @graph.builder(%[[HANDLE]])
 // CHECK:   %[[E:.*]] = call @cudnn.executable.create(%[[G]])
 // CHECK:   %[[BUF0:.*]] = hal.tensor.export %[[ARG]] "graph.arg.0"
 // CHECK:   %[[BUF1:.*]] = call @cudnn.execute.1(%[[E]], %[[BUF0]])
@@ -204,3 +204,14 @@ func.func @main(%arg: tensor<1x4x8xf32>) -> tensor<1x4x8xf32> {
 
 // CHECK: @cudnn.executable.create(!cudnn.operation_graph) -> !cudnn.executable
 // CHECK: @cudnn.execute.1(!cudnn.executable, !hal.buffer_view) -> !hal.buffer_view
+
+// -----
+
+func.func @main(%arg0: !hal.device) -> !cudnn.handle {
+  %0 = cudnn.handle(%arg0) : !cudnn.handle
+  return %0 : !cudnn.handle
+}
+
+// CHECK: func @main(%[[DEVICE:.*]]: !hal.device) -> !cudnn.handle {
+// CHECK:   call @cudnn.handle(%[[DEVICE]]) : (!hal.device) -> !cudnn.handle
+// CHECK: }

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_add_bias.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_add_bias.mlir
@@ -36,7 +36,10 @@ func.func @main() -> tensor<8x4x4x32xf32> {
   %b = util.global.load @b : tensor<8x4x4x32xf32>
   %c = util.global.load @c : tensor<1x1x1x32xf32>
 
-  %0 = cudnn.call @conv2d(%x, %w, %b, %c)
+  %device = hal.ex.shared_device : !hal.device
+  %handle = cudnn.handle(%device) : !cudnn.handle
+
+  %0 = cudnn.call handle(%handle) @conv2d(%x, %w, %b, %c)
        : (tensor<8x4x4x32xf32>, tensor<32x1x1x32xf32>,
           tensor<8x4x4x32xf32>, tensor<1x1x1x32xf32>)
        -> tensor<8x4x4x32xf32>


### PR DESCRIPTION
Context: https://github.com/openxla/iree/issues/13313

Custom modules when loaded dynamically don't have access to the HAL device, so for this reason `cudnn.handle` construction has to be explicit in the IR.