### PR TITLE
[cuDNN] Add filter tensor layouts

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNOps.cpp
@@ -84,8 +84,10 @@ static SmallVector<int64_t> getTensorArgDims(CudnnTensorType tensor) {
   // Handle one of the pre-defined cuDNN tensor layout.
   if (layout) {
     switch (*layout) {
+      case Layout::KCHW:
       case Layout::NCHW:
         return {dims[0], dims[1], dims[2], dims[3]};
+      case Layout::KHWC:
       case Layout::NHWC:
         return {dims[0], dims[2], dims[3], dims[1]};
     }

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNTypes.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/CUDNN/IR/CUDNNTypes.td
@@ -131,25 +131,34 @@ def CUDNN_ConvolutionModeAttr
 // operations, that we define as an enum attribute to avoid always passing
 // around affine maps.
 
-// 4-D Tensor layouts.
+// 4-D input tensor layouts.
 //
-// In cuDNN 4-D tensors always have their logical dimensions as NCHW (batch,
-// channels aka feature maps, height, width). Tensor layout defines how these
-// logical dimensions layed out in memory.
+// In cuDNN 4-D input tensors always have their logical dimensions as NCHW
+// (batch, channels aka feature maps, height, width). Tensor layout defines how
+// these logical dimensions layed out in memory.
 //
 // Example:
 //   `!cudnn.tensor<1x64x32x32xf32, NHWC>` is equivalent to `memref<1x32x32x64>`
 //   physical memory layout
 //
-// NCHW tensor layout is a simple row-major layout.
-def CUDNN_LAYOUT_NCHW : I32EnumAttrCase<"NCHW", 1>;
+def CUDNN_LAYOUT_NCHW : I32EnumAttrCase<"NCHW", 1>;  // row major layout
 def CUDNN_LAYOUT_NHWC : I32EnumAttrCase<"NHWC", 2>;
+
+// 4-D filter tensor layouts (for convolution operation).
+//
+// In cuDNN 4-D filter tensors always have their logical dimensions as KCHW
+// (output feature maps, input feature maps, height, width). Filter tensor
+// layout must usually match the input tensor layout.
+def CUDNN_LAYOUT_KCHW : I32EnumAttrCase<"KCHW", 3>;  // row major layout
+def CUDNN_LAYOUT_KHWC : I32EnumAttrCase<"KHWC", 4>;  // corresponds to NHWC
 
 def CUDNN_Layout : I32EnumAttr<"Layout",
     "cuDNN data layout format",
     [
       CUDNN_LAYOUT_NCHW,
-      CUDNN_LAYOUT_NHWC
+      CUDNN_LAYOUT_NHWC,
+      CUDNN_LAYOUT_KCHW,
+      CUDNN_LAYOUT_KHWC
     ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::openxla::compiler::nvgpu::cudnn";

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_api.h
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_api.h
@@ -213,12 +213,6 @@ iree::StatusOr<iree::vm::ref<CudnnTensor>> CreateTensor(
     iree::span<const int64_t> strides, int64_t uid, cudnnDataType_t dtype,
     int64_t alignment);
 
-// Creates a pointwise relu operation.
-iree::StatusOr<iree::vm::ref<CudnnTensor>> CreatePointwiseRelu(
-    openxla_cudnn_dynamic_symbols_t* syms, CudnnTensor& input,
-    double lower_clip, double upper_clip, int64_t uid, int64_t alignment,
-    bool is_virtual);
-
 // Creates a pointwise unary operation.
 iree::StatusOr<iree::vm::ref<CudnnTensor>> CreatePointwiseUnary(
     openxla_cudnn_dynamic_symbols_t* syms, cudnnPointwiseMode_t mode,
@@ -231,11 +225,15 @@ iree::StatusOr<iree::vm::ref<CudnnTensor>> CreatePointwiseBinary(
     CudnnTensor& x, float alpha, CudnnTensor& b, float alpha2, int64_t uid,
     int64_t alignment, bool is_virtual);
 
+// Creates a relu operation.
+iree::StatusOr<iree::vm::ref<CudnnTensor>> CreateRelu(
+    openxla_cudnn_dynamic_symbols_t* syms, CudnnTensor& x, double lower_clip,
+    double upper_clip, int64_t uid, int64_t alignment, bool is_virtual);
+
 // Creates a forward convolution operation.
 iree::StatusOr<iree::vm::ref<CudnnTensor>> CreateConvolution(
-    openxla_cudnn_dynamic_symbols_t* syms, CudnnTensor& input,
-    CudnnTensor& filter, iree::span<const int64_t> stride,
-    iree::span<const int64_t> pre_padding,
+    openxla_cudnn_dynamic_symbols_t* syms, CudnnTensor& x, CudnnTensor& w,
+    iree::span<const int64_t> stride, iree::span<const int64_t> pre_padding,
     iree::span<const int64_t> post_padding, iree::span<const int64_t> dilation,
     int64_t uid, int64_t alignment, bool is_virtual,
     cudnnConvolutionMode_t mode);

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
@@ -48,6 +48,8 @@ struct NHWC {
   }
 };
 
+using KHWC = NHWC;
+
 //===----------------------------------------------------------------------===//
 // Cudnn module state encapsulates all the state required for running cuDNN
 // operations (launching cuDNN graphs on a stream) at run time
@@ -269,6 +271,7 @@ static const vm::NativeFunction<State> kCudnnModuleFunctions[] = {
     // Create cuDNN tensors
     MakeNativeFunction("tensor.create.4d", &State::TensorCreate<4>),
     MakeNativeFunction("tensor.create.4d.nhwc", &State::TensorCreate<4, NHWC>),
+    MakeNativeFunction("tensor.create.4d.khwc", &State::TensorCreate<4, KHWC>),
 
     // cuDNN handle operations
     MakeNativeFunction("handle", &State::Handle),

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
@@ -92,11 +92,10 @@ class CudnnModuleState {
       std::array<vm::ref<iree_hal_buffer_view_t>, n> inputs);
 
   // Creates a pointwise relu operation and returns result tensor.
-  StatusOr<vm::ref<CudnnTensor>> PointwiseRelu(const vm::ref<CudnnTensor> input,
-                                               float lower_clip,
-                                               float upper_clip, int64_t uid,
-                                               int64_t alignment,
-                                               int32_t is_virtual);
+  StatusOr<vm::ref<CudnnTensor>> Relu(const vm::ref<CudnnTensor> input,
+                                      float lower_clip, float upper_clip,
+                                      int64_t uid, int64_t alignment,
+                                      int32_t is_virtual);
 
   // Creates a pointwise unary operation and returns a result tensor.
   template <cudnnPointwiseMode_t mode>
@@ -187,11 +186,11 @@ Status CudnnModuleState::PrintGraphDebug(
   return OkStatus();
 }
 
-StatusOr<vm::ref<CudnnTensor>> CudnnModuleState::PointwiseRelu(
+StatusOr<vm::ref<CudnnTensor>> CudnnModuleState::Relu(
     const vm::ref<CudnnTensor> input, float lower_clip, float upper_clip,
     int64_t uid, int64_t alignment, int32_t is_virtual) {
-  return CreatePointwiseRelu(syms_, *input, lower_clip, upper_clip, uid,
-                             alignment, is_virtual);
+  return CreateRelu(syms_, *input, lower_clip, upper_clip, uid, alignment,
+                    is_virtual);
 }
 
 template <cudnnPointwiseMode_t mode>
@@ -302,7 +301,7 @@ static const vm::NativeFunction<State> kCudnnModuleFunctions[] = {
 
     // cuDNN operations
     MakeNativeFunction("bias", &State::Bias),
-    MakeNativeFunction("pointwise_relu", &State::PointwiseRelu),
+    MakeNativeFunction("relu", &State::Relu),
     MakeNativeFunction("convolution.2d", &State::Convolution<2>),
 
     // Debugging operations

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_add_bias.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_add_bias.mlir
@@ -20,7 +20,7 @@ util.global @c : tensor<1x1x1x32xf32> = dense<0.5> : tensor<1x1x1x32xf32>
 util.global @w_1x1 : tensor<32x1x1x32xf32> = dense<1.0> : tensor<32x1x1x32xf32>
 
 cudnn.graph @conv2d_1x1(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
-                        %w: !cudnn.tensor<32x32x1x1xf32, NHWC>,
+                        %w: !cudnn.tensor<32x32x1x1xf32, KHWC>,
                         %b: !cudnn.tensor<8x32x4x4xf32, NHWC>,
                         %c: !cudnn.tensor<1x32x1x1xf32, NHWC>)
                          -> !cudnn.tensor<8x32x4x4xf32, NHWC> {
@@ -30,7 +30,7 @@ cudnn.graph @conv2d_1x1(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
          pre_padding=[0,0]
          post_padding=[0,0]
          dilation=[1,1]
-    : (!cudnn.tensor<8x32x4x4xf32, NHWC>, !cudnn.tensor<32x32x1x1xf32, NHWC>)
+    : (!cudnn.tensor<8x32x4x4xf32, NHWC>, !cudnn.tensor<32x32x1x1xf32, KHWC>)
     -> !cudnn.tensor<8x32x4x4xf32, NHWC>
 
   %1 = cudnn.add(%0, %b) alpha=1.0 alpha2=0.75


### PR DESCRIPTION
Add `KHWC` and `KCHW` filter tensor layouts to avoid confusion from using `NHWC` layout for convolution filters

See diff: https://github.com/ezhulenev/openxla-nvgpu/compare/compute-type...ezhulenev:openxla-nvgpu:filter-layouts