### PR TITLE
Statically link cuDNN module into IREE tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,10 @@ set(IREE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 # Enable testing before any subdirectories are added.
 enable_testing()
 
-# Customize defaults.
+#-------------------------------------------------------------------------------
+# Customize IREE defaults.
+#-------------------------------------------------------------------------------
+
 option(IREE_BUILD_COMPILER "Disable compiler for runtime-library build" ON)
 option(IREE_BUILD_SAMPLES "Disable samples for runtime-library build" OFF)
 option(IREE_HAL_DRIVER_DEFAULTS "Disable all HAL drivers by default" OFF)
@@ -33,7 +36,29 @@ option(IREE_TARGET_BACKEND_DEFAULTS "Disables target backend" OFF)
 option(IREE_TARGET_BACKEND_CUDA "Enables CUDA target backend" ON)
 option(IREE_COMPILER_BUILD_SHARED_LIBS "Enables shared libraries in the compiler by default" ON)
 
-set(IREE_COMPILER_PLUGIN_PATHS "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING "OpenXLA nvgpu plugins")
+#-------------------------------------------------------------------------------
+# Add OpenXLA Nvgpu compiler plugin to IREE compiler tools.
+#-------------------------------------------------------------------------------
+
+set(IREE_COMPILER_PLUGIN_PATHS "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING "OpenXLA Nvgpu plugins")
+
+#-------------------------------------------------------------------------------
+# Add OpenXLA Nvgpu runtime modules too IREE runtime tools.
+#-------------------------------------------------------------------------------
+
+set(IREE_EXTERNAL_TOOLING_MODULES "cudnn" CACHE STRING "OpenXLA Nvgpu cuDNN module")
+
+set(IREE_EXTERNAL_TOOLING_MODULE_CUDNN_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime/src/openxla/runtime/nvgpu" CACHE STRING "OpenXLA Nvgpu cuDNN module source dir")
+set(IREE_EXTERNAL_TOOLING_MODULE_CUDNN_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/runtime/src/openxla/runtime/nvgpu" CACHE STRING "OpenXLA Nvgpu cuDNN module binary dir")
+set(IREE_EXTERNAL_TOOLING_MODULE_CUDNN_TARGET "openxla_runtime_nvgpu_cudnn_module" CACHE STRING "OpenXLA Nvgpu cuDNN module target")
+set(IREE_EXTERNAL_TOOLING_MODULE_CUDNN_NAME "cudnn" CACHE STRING "OpenXLA Nvgpu cuDNN module name")
+set(IREE_EXTERNAL_TOOLING_MODULE_CUDNN_REGISTER_TYPES "openxla_nvgpu_cudnn_module_register_types" CACHE STRING "OpenXLA Nvgpu cuDNN module type registration")
+set(IREE_EXTERNAL_TOOLING_MODULE_CUDNN_CREATE "openxla_nvgpu_cudnn_module_create" CACHE STRING "OpenXLA Nvgpu cuDNN module creator")
+
+#-------------------------------------------------------------------------------
+# Set up IREE toolchain with OpenXLA Nvgpu modules.
+#-------------------------------------------------------------------------------
+
 add_subdirectory("${IREE_ROOT_DIR}" "iree_core")
 
 # Handle various global definitions that need to be set at the global

--- a/runtime/src/openxla/runtime/nvgpu/cudnn_module.h
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn_module.h
@@ -10,14 +10,11 @@
 #include "iree/base/api.h"
 #include "iree/vm/api.h"
 
-namespace openxla::runtime::nvgpu {
+extern "C" iree_status_t openxla_nvgpu_cudnn_module_create(
+    iree_vm_instance_t* instance, iree_allocator_t host_allocator,
+    iree_vm_module_t** out_module);
 
-iree_status_t CreateCudnnModule(iree_vm_instance_t* instance,
-                                iree_allocator_t host_allocator,
-                                iree_vm_module_t** out_module);
-
-iree_status_t RegisterCudnnTypes(iree_vm_instance_t* instance);
-
-}  // namespace openxla::runtime::nvgpu
+extern "C" iree_status_t openxla_nvgpu_cudnn_module_register_types(
+    iree_vm_instance_t* instance);
 
 #endif  // OPENXLA_RUNTIME_NVGPU_CUDNN_MODULE_H_

--- a/tools/openxla-runner.cpp
+++ b/tools/openxla-runner.cpp
@@ -11,8 +11,6 @@
 #include "iree/tooling/vm_util.h"
 #include "openxla/runtime/nvgpu/cudnn_module.h"
 
-using namespace openxla::runtime::nvgpu;
-
 // TODO: This is a temporary work around missing custom modules integration into
 // IREE tools (iree-run-module). We already have flags to enable plugins in
 // compiler tools (`iree-compiler` and `iree-opt`), but not yet in "runtime"
@@ -42,8 +40,8 @@ int main(int argc, char** argv) {
                                              &instance));
 
   // Register custom types define by cuDNN module.
-  IREE_CHECK_OK(
-      RegisterCudnnTypes(iree_runtime_instance_vm_instance(instance)));
+  IREE_CHECK_OK(openxla_nvgpu_cudnn_module_register_types(
+      iree_runtime_instance_vm_instance(instance)));
 
   // Try to create the CUDA device.
   iree_hal_device_t* device = NULL;
@@ -60,8 +58,9 @@ int main(int argc, char** argv) {
 
   // Create the custom module that can be reused across contexts.
   iree_vm_module_t* custom_module = NULL;
-  IREE_CHECK_OK(CreateCudnnModule(iree_runtime_instance_vm_instance(instance),
-                                  host_allocator, &custom_module));
+  IREE_CHECK_OK(openxla_nvgpu_cudnn_module_create(
+      iree_runtime_instance_vm_instance(instance), host_allocator,
+      &custom_module));
   IREE_CHECK_OK(iree_runtime_session_append_module(session, custom_module));
   iree_vm_module_release(custom_module);
 


### PR DESCRIPTION
Use static linking mechanism to always link cuDNN module into `iree-run-module` and `iree-benchmark-module`