### PR TITLE
Configure runtime LIT tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ option(IREE_COMPILER_BUILD_SHARED_LIBS "Enables shared libraries in the compiler
 find_package(Python3 COMPONENTS Interpreter QUIET)
 
 set(IREE_TEST_TMPDIR_ROOT "${CMAKE_CURRENT_BINARY_DIR}/test_tmpdir")
-set(LLVM_EXTERNAL_LIT "${IREE_SOURCE_DIR}/third_party/llvm-project/llvm/utils/lit/lit.py")
+set(LLVM_EXTERNAL_LIT "${IREE_ROOT_DIR}/third_party/llvm-project/llvm/utils/lit/lit.py")
 
 #-------------------------------------------------------------------------------
 # Add OpenXLA Nvgpu compiler plugin to IREE compiler tools.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,19 @@ option(IREE_TARGET_BACKEND_CUDA "Enables CUDA target backend" ON)
 option(IREE_COMPILER_BUILD_SHARED_LIBS "Enables shared libraries in the compiler by default" ON)
 
 #-------------------------------------------------------------------------------
+# Customize IREE LIT test runner.
+#-------------------------------------------------------------------------------
+
+# TODO(ezhulenev): Python3 executable and LLVM LIT are required for running lit
+# tests under `runtime` folder. Figure out how to initialize them as a part of
+# `iree_setup_toolchain` invoked below.
+
+find_package(Python3 COMPONENTS Interpreter QUIET)
+
+set(IREE_TEST_TMPDIR_ROOT "${CMAKE_CURRENT_BINARY_DIR}/test_tmpdir")
+set(LLVM_EXTERNAL_LIT "${IREE_SOURCE_DIR}/third_party/llvm-project/llvm/utils/lit/lit.py")
+
+#-------------------------------------------------------------------------------
 # Add OpenXLA Nvgpu compiler plugin to IREE compiler tools.
 #-------------------------------------------------------------------------------
 

--- a/runtime/src/lit.cfg.py
+++ b/runtime/src/lit.cfg.py
@@ -1,0 +1,32 @@
+# Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Lit config for OpenXLA."""
+
+# Lint for undefined variables is disabled as config is not defined inside this
+# file, instead config is injected by way of evaluating runlit.cfg.py from
+# runlit.site.cfg.py which in turn is evaluated by lit.py.
+# pylint: disable=undefined-variable
+
+import os
+import tempfile
+
+import lit.formats
+
+config.name = "OpenXLA"
+config.suffixes = [".mlir"]
+config.test_format = lit.formats.ShTest(execute_external=True)
+
+passthrough_env_vars = []
+config.environment.update({
+    k: v
+    for k, v in os.environ.items()
+    if k.startswith("IREE_") or k in passthrough_env_vars
+})
+
+# Use the most preferred temp directory.
+config.test_exec_root = (os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or
+                         os.environ.get("TEST_TMPDIR") or
+                         os.path.join(tempfile.gettempdir(), "lit"))

--- a/runtime/src/openxla/runtime/nvgpu/CMakeLists.txt
+++ b/runtime/src/openxla/runtime/nvgpu/CMakeLists.txt
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+iree_add_all_subdirs()
+
 iree_cc_library(
   NAME
     defs

--- a/runtime/src/openxla/runtime/nvgpu/benchmark/CMakeLists.txt
+++ b/runtime/src/openxla/runtime/nvgpu/benchmark/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if(NOT IREE_HAL_DRIVER_CUDA OR NOT IREE_TARGET_BACKEND_CUDA)
+  return()
+endif()
+
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "conv2d_add_bias_cudnn.mlir"
+    "conv2d_add_bias_mhlo.mlir"
+  TOOLS
+    FileCheck
+    iree-compile
+  LABELS
+    "driver=cuda"
+)

--- a/runtime/src/openxla/runtime/nvgpu/benchmark/conv2d_add_bias_cudnn.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/benchmark/conv2d_add_bias_cudnn.mlir
@@ -1,4 +1,6 @@
-module @example {
+// RUN: iree-compile --compile-to=vm --iree-plugin=openxla_nvgpu               \
+// RUN:              --iree-input-type=mhlo --iree-hal-target-backends=cuda %s \
+// RUN: | FileCheck %s
 
 util.global @handle : !cudnn.handle
 
@@ -13,6 +15,7 @@ util.initializer {
 // 1x1 convolution
 //===-----------------------------------------------------------------------===/
 
+// CHECK: vm.func private @cudnn.conv2d_1x1.builder
 cudnn.graph @cudnn.conv2d_1x1(%x: !cudnn.tensor<8x32x256x256xf32, NHWC>,
                               %w: !cudnn.tensor<32x32x1x1xf32, NHWC>,
                               %b: !cudnn.tensor<8x32x256x256xf32, NHWC>,
@@ -41,6 +44,7 @@ cudnn.graph @cudnn.conv2d_1x1(%x: !cudnn.tensor<8x32x256x256xf32, NHWC>,
   cudnn.return %2: !cudnn.tensor<8x32x256x256xf32, NHWC>
 }
 
+// CHECK: vm.func private @conv2d_1x1
 func.func @conv2d_1x1(
   %x: tensor<8x256x256x32xf32>,
   %w: tensor<32x1x1x32xf32>,
@@ -64,6 +68,7 @@ func.func @conv2d_1x1(
 // 3x3 convolution
 //===-----------------------------------------------------------------------===/
 
+// CHECK: vm.func private @cudnn.conv2d_3x3.builder
 cudnn.graph @cudnn.conv2d_3x3(%x: !cudnn.tensor<8x32x256x256xf32, NHWC>,
                               %w: !cudnn.tensor<32x32x3x3xf32, NHWC>,
                               %b: !cudnn.tensor<8x32x256x256xf32, NHWC>,
@@ -92,6 +97,7 @@ cudnn.graph @cudnn.conv2d_3x3(%x: !cudnn.tensor<8x32x256x256xf32, NHWC>,
   cudnn.return %2: !cudnn.tensor<8x32x256x256xf32, NHWC>
 }
 
+// CHECK: vm.func private @conv2d_3x3
 func.func @conv2d_3x3(
   %x: tensor<8x256x256x32xf32>,
   %w: tensor<32x3x3x32xf32>,
@@ -109,6 +115,4 @@ func.func @conv2d_3x3(
   %1 = mhlo.sqrt %0 : tensor<8x256x256x32xf32>
 
   return %0 : tensor<8x256x256x32xf32>
-}
-
 }

--- a/runtime/src/openxla/runtime/nvgpu/benchmark/conv2d_add_bias_mhlo.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/benchmark/conv2d_add_bias_mhlo.mlir
@@ -1,9 +1,12 @@
-module @example {
+// RUN: iree-compile --compile-to=vm --iree-plugin=openxla_nvgpu               \
+// RUN:              --iree-input-type=mhlo --iree-hal-target-backends=cuda %s \
+// RUN: | FileCheck %s
 
 //===-----------------------------------------------------------------------===/
 // 1x1 convolution
 //===-----------------------------------------------------------------------===/
 
+// CHECK: vm.func private @conv2d_1x1
 func.func @conv2d_1x1(
   %x: tensor<8x256x256x32xf32>,
   %w: tensor<1x1x32x32xf32>,
@@ -43,6 +46,7 @@ func.func @conv2d_1x1(
 // 3x3 convolution
 //===-----------------------------------------------------------------------===/
 
+// CHECK: vm.func private @conv2d_3x3
 func.func @conv2d_3x3(
   %x: tensor<8x256x256x32xf32>,
   %w: tensor<3x3x32x32xf32>,
@@ -76,6 +80,4 @@ func.func @conv2d_3x3(
   %3 = mhlo.add %1, %2 : tensor<8x256x256x32xf32>
 
   return %3 : tensor<8x256x256x32xf32>
-}
-
 }

--- a/runtime/src/openxla/runtime/nvgpu/test/CMakeLists.txt
+++ b/runtime/src/openxla/runtime/nvgpu/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright 2023 The OpenXLA Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if(NOT IREE_HAL_DRIVER_CUDA OR NOT IREE_TARGET_BACKEND_CUDA)
+  return()
+endif()
+
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "conv2d_add_bias.mlir"
+  TOOLS
+    FileCheck
+    iree-compile
+    iree-run-module
+  LABELS
+    "driver=cuda"
+)

--- a/runtime/src/openxla/runtime/nvgpu/test/CMakeLists.txt
+++ b/runtime/src/openxla/runtime/nvgpu/test/CMakeLists.txt
@@ -13,6 +13,10 @@ iree_lit_test_suite(
     lit
   SRCS
     "conv2d_add_bias.mlir"
+    "conv2d_batch_norm_add_max.mlir"
+    "conv2d_batch_norm_expanded.mlir"
+    "conv2d_batch_norm.mlir"
+    "conv2d.mlir"
   TOOLS
     FileCheck
     iree-compile

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d.mlir
@@ -1,4 +1,16 @@
-module @example {
+// RUN: iree-compile --iree-plugin=openxla_nvgpu --iree-input-type=mhlo        \
+// RUN:              --iree-hal-target-backends=cuda %s                        \
+// RUN: | iree-run-module --module=- --device=cuda --function=main             \
+// RUN: | FileCheck %s
+
+util.global @handle : !cudnn.handle
+
+util.initializer {
+  %device = hal.ex.shared_device : !hal.device
+  %handle = cudnn.handle(%device) : !cudnn.handle
+  util.global.store %handle, @handle : !cudnn.handle
+  util.initializer.return
+}
 
 cudnn.graph @conv2d(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
                     %w: !cudnn.tensor<32x32x1x1xf32, NHWC>)
@@ -17,14 +29,16 @@ cudnn.graph @conv2d(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
 util.global @x : tensor<8x4x4x32xf32> = dense<1.0> : tensor<8x4x4x32xf32>
 util.global @w : tensor<32x1x1x32xf32> = dense<1.0> : tensor<32x1x1x32xf32>
 
+// CHECK: result[0]: hal.buffer_view
+// CHECK: 32 32 32 32 32 32 32 32 32
 func.func @main() -> tensor<8x4x4x32xf32> {
   %x = util.global.load @x : tensor<8x4x4x32xf32>
   %w = util.global.load @w : tensor<32x1x1x32xf32>
 
-  %0 = cudnn.call @conv2d(%x, %w)
+  %handle = util.global.load @handle : !cudnn.handle
+
+  %0 = cudnn.call handle(%handle) @conv2d(%x, %w)
        : (tensor<8x4x4x32xf32>, tensor<32x1x1x32xf32>) -> tensor<8x4x4x32xf32>
 
   return %0 : tensor<8x4x4x32xf32>
-}
-
 }

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_add_bias.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_add_bias.mlir
@@ -1,3 +1,13 @@
+// RUN: iree-compile --iree-plugin=openxla_nvgpu --iree-input-type=mhlo        \
+// RUN:              --iree-hal-target-backends=cuda %s                        \
+// RUN: | iree-run-module --module=- --device=cuda --function=run.conv2d_1x1   \
+// RUN: | FileCheck %s --check-prefix=CHECK_1X1
+
+// RUN: iree-compile --iree-plugin=openxla_nvgpu --iree-input-type=mhlo        \
+// RUN:              --iree-hal-target-backends=cuda %s                        \
+// RUN: | iree-run-module --module=- --device=cuda --function=run.conv2d_3x3   \
+// RUN: | FileCheck %s --check-prefix=CHECK_3X3
+
 module @example {
 
 util.global @handle : !cudnn.handle
@@ -19,6 +29,9 @@ util.global @c : tensor<1x1x1x32xf32> = dense<0.5> : tensor<1x1x1x32xf32>
 
 util.global @w_1x1 : tensor<32x1x1x32xf32> = dense<1.0> : tensor<32x1x1x32xf32>
 
+
+// CHECK_1X1: result[0]: hal.buffer_view
+// CHECK_1X1: 34 34 34 34 34 34 34 34 34
 cudnn.graph @conv2d_1x1(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
                         %w: !cudnn.tensor<32x32x1x1xf32, KHWC>,
                         %b: !cudnn.tensor<8x32x4x4xf32, NHWC>,
@@ -67,6 +80,10 @@ func.func @run.conv2d_1x1() -> tensor<8x4x4x32xf32> {
 
 util.global @w_3x3 : tensor<32x3x3x32xf32> = dense<1.0> : tensor<32x3x3x32xf32>
 
+// CHECK_3X3: result[0]: hal.buffer_view
+// CHECK_3X3: 130 130 130 130 130 130 130
+// CHECK_3X3: 194 194 194 194 194 194 194
+// CHECK_3x3: 290 290 290 290 290 290 290
 cudnn.graph @conv2d_3x3(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
                         %w: !cudnn.tensor<32x32x3x3xf32, NHWC>,
                         %b: !cudnn.tensor<8x32x4x4xf32, NHWC>,

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_add_bias.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_add_bias.mlir
@@ -8,8 +8,6 @@
 // RUN: | iree-run-module --module=- --device=cuda --function=run.conv2d_3x3   \
 // RUN: | FileCheck %s --check-prefix=CHECK_3X3
 
-module @example {
-
 util.global @handle : !cudnn.handle
 
 util.initializer {
@@ -28,7 +26,6 @@ util.global @c : tensor<1x1x1x32xf32> = dense<0.5> : tensor<1x1x1x32xf32>
 //===-----------------------------------------------------------------------===/
 
 util.global @w_1x1 : tensor<32x1x1x32xf32> = dense<1.0> : tensor<32x1x1x32xf32>
-
 
 // CHECK_1X1: result[0]: hal.buffer_view
 // CHECK_1X1: 34 34 34 34 34 34 34 34 34
@@ -124,6 +121,4 @@ func.func @run.conv2d_3x3() -> tensor<8x4x4x32xf32> {
        -> tensor<8x4x4x32xf32>
 
   return %0 : tensor<8x4x4x32xf32>
-}
-
 }

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm.mlir
@@ -47,7 +47,7 @@ util.global @variance : tensor<1x1x1x32xf32> = dense<0.2> : tensor<1x1x1x32xf32>
 util.global @epsilon : tensor<1x1x1x1xf32> = dense<0.0001> : tensor<1x1x1x1xf32>
 
 // CHECK: result[0]: hal.buffer_view
-// CHECK: 32 32 32 32 32 32 32 32 32
+// CHECK: 36.4887 36.4887 36.4887 36.4887 36.4887
 func.func @main() -> tensor<8x4x4x32xf32> {
   %x = util.global.load @x : tensor<8x4x4x32xf32>
   %w = util.global.load @w : tensor<32x1x1x32xf32>

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm_add_max.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm_add_max.mlir
@@ -57,7 +57,7 @@ util.global @epsilon : tensor<1x1x1x1xf32> = dense<0.0001> : tensor<1x1x1x1xf32>
 util.global @max : tensor<8x4x4x32xf32> = dense<38.0> : tensor<8x4x4x32xf32>
 
 // CHECK: result[0]: hal.buffer_view
-// CHECK: 32 32 32 32 32 32 32 32 32
+// CHECK: 38 38 38 38 38 38 38 38 38
 func.func @main() -> tensor<8x4x4x32xf32> {
   %x = util.global.load @x : tensor<8x4x4x32xf32>
   %w = util.global.load @w : tensor<32x1x1x32xf32>

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm_add_max.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm_add_max.mlir
@@ -1,4 +1,16 @@
-module @example {
+// RUN: iree-compile --iree-plugin=openxla_nvgpu --iree-input-type=mhlo        \
+// RUN:              --iree-hal-target-backends=cuda %s                        \
+// RUN: | iree-run-module --module=- --device=cuda --function=main             \
+// RUN: | FileCheck %s
+
+util.global @handle : !cudnn.handle
+
+util.initializer {
+  %device = hal.ex.shared_device : !hal.device
+  %handle = cudnn.handle(%device) : !cudnn.handle
+  util.global.store %handle, @handle : !cudnn.handle
+  util.initializer.return
+}
 
 cudnn.graph @conv2d(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
                     %w: !cudnn.tensor<32x32x1x1xf32, NHWC>,
@@ -44,6 +56,8 @@ util.global @variance : tensor<1x1x1x32xf32> = dense<0.2> : tensor<1x1x1x32xf32>
 util.global @epsilon : tensor<1x1x1x1xf32> = dense<0.0001> : tensor<1x1x1x1xf32>
 util.global @max : tensor<8x4x4x32xf32> = dense<38.0> : tensor<8x4x4x32xf32>
 
+// CHECK: result[0]: hal.buffer_view
+// CHECK: 32 32 32 32 32 32 32 32 32
 func.func @main() -> tensor<8x4x4x32xf32> {
   %x = util.global.load @x : tensor<8x4x4x32xf32>
   %w = util.global.load @w : tensor<32x1x1x32xf32>
@@ -54,13 +68,14 @@ func.func @main() -> tensor<8x4x4x32xf32> {
   %epsilon = util.global.load @epsilon : tensor<1x1x1x1xf32>
   %max = util.global.load @max : tensor<8x4x4x32xf32>
 
-  %0 = cudnn.call @conv2d(%x, %w, %scale, %offset, %mean, %var, %epsilon, %max)
+  %handle = util.global.load @handle : !cudnn.handle
+
+  %0 = cudnn.call handle(%handle)
+                  @conv2d(%x, %w, %scale, %offset, %mean, %var, %epsilon, %max)
        : (tensor<8x4x4x32xf32>, tensor<32x1x1x32xf32>, tensor<1x1x1x32xf32>,
           tensor<1x1x1x32xf32>, tensor<1x1x1x32xf32>, tensor<1x1x1x32xf32>,
           tensor<1x1x1x1xf32>, tensor<8x4x4x32xf32>)
        -> tensor<8x4x4x32xf32>
 
   return %0 : tensor<8x4x4x32xf32>
-}
-
 }

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm_expanded.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm_expanded.mlir
@@ -72,7 +72,7 @@ util.global @variance : tensor<1x1x1x32xf32> = dense<0.2> : tensor<1x1x1x32xf32>
 util.global @epsilon : tensor<1x1x1x1xf32> = dense<0.0001> : tensor<1x1x1x1xf32>
 
 // CHECK: result[0]: hal.buffer_view
-// CHECK: 32 32 32 32 32 32 32 32 32
+// CHECK: 36.4887 36.4887 36.4887 36.4887 36.4887
 func.func @main() -> tensor<8x4x4x32xf32> {
   %x = util.global.load @x : tensor<8x4x4x32xf32>
   %w = util.global.load @w : tensor<32x1x1x32xf32>

--- a/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm_expanded.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/test/conv2d_batch_norm_expanded.mlir
@@ -1,4 +1,16 @@
-module @example {
+// RUN: iree-compile --iree-plugin=openxla_nvgpu --iree-input-type=mhlo        \
+// RUN:              --iree-hal-target-backends=cuda %s                        \
+// RUN: | iree-run-module --module=- --device=cuda --function=main             \
+// RUN: | FileCheck %s
+
+util.global @handle : !cudnn.handle
+
+util.initializer {
+  %device = hal.ex.shared_device : !hal.device
+  %handle = cudnn.handle(%device) : !cudnn.handle
+  util.global.store %handle, @handle : !cudnn.handle
+  util.initializer.return
+}
 
 cudnn.graph @conv2d(%x: !cudnn.tensor<8x32x4x4xf32, NHWC>,
                     %w: !cudnn.tensor<32x32x1x1xf32, NHWC>,
@@ -59,6 +71,8 @@ util.global @mean : tensor<1x1x1x32xf32> = dense<0.25> : tensor<1x1x1x32xf32>
 util.global @variance : tensor<1x1x1x32xf32> = dense<0.2> : tensor<1x1x1x32xf32>
 util.global @epsilon : tensor<1x1x1x1xf32> = dense<0.0001> : tensor<1x1x1x1xf32>
 
+// CHECK: result[0]: hal.buffer_view
+// CHECK: 32 32 32 32 32 32 32 32 32
 func.func @main() -> tensor<8x4x4x32xf32> {
   %x = util.global.load @x : tensor<8x4x4x32xf32>
   %w = util.global.load @w : tensor<32x1x1x32xf32>
@@ -68,13 +82,14 @@ func.func @main() -> tensor<8x4x4x32xf32> {
   %variance = util.global.load @variance : tensor<1x1x1x32xf32>
   %epsilon = util.global.load @epsilon : tensor<1x1x1x1xf32>
 
-  %0 = cudnn.call @conv2d(%x, %w, %scale, %offset, %mean, %variance, %epsilon)
+  %handle = util.global.load @handle : !cudnn.handle
+
+  %0 = cudnn.call handle(%handle)
+                  @conv2d(%x, %w, %scale, %offset, %mean, %variance, %epsilon)
        : (tensor<8x4x4x32xf32>, tensor<32x1x1x32xf32>, tensor<1x1x1x32xf32>,
           tensor<1x1x1x32xf32>, tensor<1x1x1x32xf32>, tensor<1x1x1x32xf32>,
           tensor<1x1x1x1xf32>)
        -> tensor<8x4x4x32xf32>
 
   return %0 : tensor<8x4x4x32xf32>
-}
-
 }


### PR DESCRIPTION
```
ctest --test-dir build -R openxla/runtime/nvgpu/


Internal ctest changing into directory: /usr/local/google/home/ezhulenev/a6000/openxla-nvgpu/build
Test project /usr/local/google/home/ezhulenev/a6000/openxla-nvgpu/build
    Start 1041: openxla/runtime/nvgpu/benchmark/conv2d_add_bias_cudnn.mlir.test
1/7 Test #1041: openxla/runtime/nvgpu/benchmark/conv2d_add_bias_cudnn.mlir.test ...   Passed    2.43 sec
    Start 1042: openxla/runtime/nvgpu/benchmark/conv2d_add_bias_mhlo.mlir.test
2/7 Test #1042: openxla/runtime/nvgpu/benchmark/conv2d_add_bias_mhlo.mlir.test ....   Passed    5.73 sec
    Start 1043: openxla/runtime/nvgpu/test/conv2d_add_bias.mlir.test
3/7 Test #1043: openxla/runtime/nvgpu/test/conv2d_add_bias.mlir.test ..............   Passed   12.15 sec
    Start 1044: openxla/runtime/nvgpu/test/conv2d_batch_norm_add_max.mlir.test
4/7 Test #1044: openxla/runtime/nvgpu/test/conv2d_batch_norm_add_max.mlir.test ....   Passed    7.24 sec
    Start 1045: openxla/runtime/nvgpu/test/conv2d_batch_norm_expanded.mlir.test
5/7 Test #1045: openxla/runtime/nvgpu/test/conv2d_batch_norm_expanded.mlir.test ...   Passed    6.94 sec
    Start 1046: openxla/runtime/nvgpu/test/conv2d_batch_norm.mlir.test
6/7 Test #1046: openxla/runtime/nvgpu/test/conv2d_batch_norm.mlir.test ............   Passed    6.83 sec
    Start 1047: openxla/runtime/nvgpu/test/conv2d.mlir.test
7/7 Test #1047: openxla/runtime/nvgpu/test/conv2d.mlir.test .......................   Passed    5.82 sec
```