### PR TITLE
Set unique options category name

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/PluginRegistration.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/PluginRegistration.cpp
@@ -37,7 +37,7 @@ struct NvgpuOptions {
   bool flag = false;
 
   void bindOptions(OptionsBinder &binder) {
-    static llvm::cl::OptionCategory category("IREE Example Plugin");
+    static llvm::cl::OptionCategory category("OpenXLA NVGPU Plugin");
     binder.opt<bool>("openxla-nvgpu-flag", flag,
                      llvm::cl::desc("Dummy flag for the nvgpu plugin"),
                      llvm::cl::cat(category));


### PR DESCRIPTION
This fixes a compile error when compiling IREE with the OpenXLA NVGPU plugin. There is another plugin
(samples/compiler_plugins/example/src/PluginRegistration.cpp) with the same name.