### PR TITLE
Change category name for plugin registration

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/PluginRegistration.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/PluginRegistration.cpp
@@ -37,7 +37,7 @@ struct NvgpuOptions {
   bool flag = false;
 
   void bindOptions(OptionsBinder &binder) {
-    static llvm::cl::OptionCategory category("IREE Example Plugin");
+    static llvm::cl::OptionCategory category("IREE NVGPU Plugin");
     binder.opt<bool>("openxla-nvgpu-flag", flag,
                      llvm::cl::desc("Dummy flag for the nvgpu plugin"),
                      llvm::cl::cat(category));


### PR DESCRIPTION
IREE already registers a plugin with the same category names. Thus using this project as an IREE plugin asserts with `Duplicate option categories`.