### PR TITLE
Update triton submodule to HEAD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = git@github.com:NVIDIA/cudnn-frontend.git
 [submodule "third_party/triton"]
 	path = third_party/triton
-	url = git@github.com:ezhulenev/triton.git
-	branch = openxla-triton
+	url = https://github.com/openai/triton.git


### PR DESCRIPTION
openai/triton@17eb982771e939406b6f801d80d51498507893dd

The commit that the submodule points to at the moment does not contain the required patches that were mentioned in #76. These patches have landed in the meantime, so we can use openai/triton directly.