### PR TITLE
Add transform dialect interpreter preprocessing plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = git@github.com:NVIDIA/cudnn-frontend.git
 [submodule "third_party/triton"]
 	path = third_party/triton
-	url = git@github.com:ezhulenev/triton.git
-	branch = openxla-triton
+	url = https://github.com/openai/triton.git


### PR DESCRIPTION
Add a new plugin option to specify a transform dialect script that
should be executed as part of the preprocessing pipeline. This makes it
possible to perform GPU-specific preprocessing without a custom hook in
one of the IREE pipelines.

Usage:
```
iree-compile ... --iree_plugin=openxla-transform -openxla-transform-preprocessing=file.mlir
```
Depends on #83.
