### PR TITLE
[Triton] Add triton executable ops + verifiers + tests

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Conversion/ConvertTritonToFlowDispatch.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Conversion/ConvertTritonToFlowDispatch.cpp
@@ -188,11 +188,12 @@ static FailureOr<std::string> compileTritonFunctionToPTX(
 
 using llvm::sys::fs::TempFile;
 
-struct ConvertTritonFlowDispatchOp : public OpConversionPattern<DispatchOp> {
+struct ConvertTritonFlowCallOp
+    : public OpConversionPattern<tritonflow::CallOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult matchAndRewrite(
-      DispatchOp op, OpAdaptor adaptor,
+      tritonflow::CallOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     MLIRContext *ctx = getContext();
 
@@ -348,7 +349,7 @@ struct ConvertTritonFlowDispatchOp : public OpConversionPattern<DispatchOp> {
 void populateTritonToFlowDispatchPatterns(TypeConverter &typeConverter,
                                           RewritePatternSet &patterns) {
   MLIRContext *ctx = patterns.getContext();
-  patterns.insert<ConvertTritonFlowDispatchOp>(typeConverter, ctx);
+  patterns.insert<ConvertTritonFlowCallOp>(typeConverter, ctx);
 }
 
 }  // namespace openxla::compiler::nvgpu::tritonflow

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/BUILD.bazel
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
     deps = [
         ":TritonFlowOpsGen",
         "//compiler/src/openxla/compiler/nvgpu:defs",
+        "@iree_core//compiler/src/iree/compiler/Dialect/Util/IR",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/CMakeLists.txt
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
     LLVMSupport
     MLIRIR
     MLIRSupport
+    iree::compiler::Dialect::Util::IR
     openxla::compiler::nvgpu::defs
   PUBLIC
 )

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowDialect.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowDialect.td
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TRITON_DIALECT
-#define TRITON_DIALECT
+#ifndef TRITONFLOW_DIALECT
+#define TRITONFLOW_DIALECT
 
 include "mlir/IR/OpBase.td"
 
@@ -18,23 +18,6 @@ def TritonFlow_Dialect : Dialect {
   }];
 }
 
-def TritonFlow_Dim : TypeAlias<Index>;
-
-//===----------------------------------------------------------------------===//
-// General types and helpers
-//===----------------------------------------------------------------------===//
-
-class TritonFlow_SymbolRefAttr :
-        Attr<CPred<"$_self.isa<mlir::FlatSymbolRefAttr>()">,
-             "symbol reference attribute"> {
-  let storageType = [{ mlir::FlatSymbolRefAttr }];
-  let returnType = [{ mlir::StringRef }];
-  let valueType = NoneType;
-  let constBuilderCall = "mlir::SymbolRefAttr::get($_builder.getContext(), $0)";
-}
-
-def TritonFlow_FuncRefAttr : TritonFlow_SymbolRefAttr;
-
 //===----------------------------------------------------------------------===//
 // Base operation definition
 //===----------------------------------------------------------------------===//
@@ -42,4 +25,4 @@ def TritonFlow_FuncRefAttr : TritonFlow_SymbolRefAttr;
 class TritonFlow_Op<string mnemonic, list<Trait> traits = []> :
         Op<TritonFlow_Dialect, mnemonic, traits>;
 
-#endif // TRITON_DIALECT
+#endif // TRITONFLOW_DIALECT

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.h
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.h
@@ -7,6 +7,7 @@
 #ifndef OPENXLA_COMPILER_NVGPU_DIALECT_TRITONFLOW_IR_TRITONFLOW_OPS_H
 #define OPENXLA_COMPILER_NVGPU_DIALECT_TRITONFLOW_IR_TRITONFLOW_OPS_H
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/FunctionInterfaces.h"

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.td
@@ -13,21 +13,111 @@ include "mlir/IR/SymbolInterfaces.td"
 include "openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowDialect.td"
 
 //===----------------------------------------------------------------------===//
-// triton.dispatch operation
+// triton.executable operation
 //===----------------------------------------------------------------------===//
 
-// TODO(ezhulenev): We should follow Flow dialect design and introduce Triton
-// executable to carry Triton compilation options. For now we just dispatch
-// a Triton function and hardcode all other parameters.
-
-def TritonFlow_DispatchOp : TritonFlow_Op<"dispatch", [
-    AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<SymbolUserOpInterface>
-  ]> {
-  let summary = "Triton dispatch operation";
+def TritonFlow_ExecutableOp : TritonFlow_Op<"executable", [
+    IsolatedFromAbove,
+    SingleBlockImplicitTerminator<"ExecutableEndOp">,
+    NativeOpTrait<"SymbolTable">,
+    Symbol
+]> {
+  let summary = "Triton executable module";
 
   let description = [{
-    Dispatches a Triton function with the given arguments.
+    A Triton executable module containing one or more public Triton functions.
+    The contents of the functions are safe to dispatch and can be lowered
+    further to target-specific backend IR representation using Triton compiler
+    passes. This is very similar to the `flow.executable` operation but
+    specialized for the Triton compiler, while the `flow.executable` is a part
+    of builtin IREE compilation pipeline.
+  }];
+
+  let arguments = (ins
+    OptionalAttr<StrAttr>:$sym_visibility,
+    SymbolNameAttr:$sym_name
+  );
+
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    custom<SymbolVisibility>($sym_visibility)
+    $sym_name
+    attr-dict-with-keyword
+    regions
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::Block& getBlock() { return getBody().front(); }
+    ::mlir::ModuleOp getInnerModule() {
+      return *getBlock().getOps<::mlir::ModuleOp>().begin();
+    }
+  }];
+
+  let hasVerifier = 1;
+}
+
+def TritonFlow_ExecutableEndOp : TritonFlow_Op<"executable_end", [
+  HasParent<"ExecutableOp">,
+  Terminator,
+]> {
+  let summary = "terminator pseudo-op for the executable op";
+  let assemblyFormat = "attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// triton.executable.export operation
+//===----------------------------------------------------------------------===//
+
+// TODO(ezhulenev): We might use this mechanism for exporting the same Triton
+// function with different Triton compiler options (num_stages, num_warps), or
+// specializing for constant values (if/when tl.constexpr will be available in
+// Triton MLIR dialect), and custom dispatch grid calculation. Currently it
+// only exports a function from the nested module (maybe with an alias).
+
+// TODO(ezhulenev): Should we have a pipeline layout attribute here? Or infer it
+// automatically later once lowering to HAL executable? Consider adding optional
+// layout, it might be easier to infer it early while the inner module is still
+// at Triton level, and don't wait for lowering to LLVM.
+
+def TritonFlow_ExecutableExportOp : TritonFlow_Op<"executable.export", [
+  HasParent<"ExecutableOp">,
+  Symbol,
+  IsolatedFromAbove,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "defines a Triton executable entry point for dispatches";
+
+  let description = [{
+    Specifies an exported function with an externally-visible alias. Multiple
+    exports can reference the same internal function.
+  }];
+
+  let arguments = (ins
+    OptionalAttr<StrAttr>:$sym_visibility,
+    SymbolNameAttr:$sym_name,
+    FlatSymbolRefAttr:$function_ref
+  );
+
+  let assemblyFormat = [{
+    custom<SymbolVisibility>($sym_visibility)
+    custom<SymbolAlias>($sym_name, $function_ref)
+    attr-dict-with-keyword
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// triton.call operation
+//===----------------------------------------------------------------------===//
+
+def TritonFlow_CallOp : TritonFlow_Op<"call", [
+    AttrSizedOperandSegments,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Triton call operation";
+
+  let description = [{
+    Calls a Triton function with the given arguments.
   }];
 
   let arguments = (ins

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.td
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef TRITON_OPS
-#define TRITON_OPS
+#ifndef TRITONFLOW_OPS
+#define TRITONFLOW_OPS
 
 include "mlir/IR/OpBase.td"
 include "mlir/IR/SymbolInterfaces.td"
@@ -107,8 +107,52 @@ def TritonFlow_ExecutableExportOp : TritonFlow_Op<"executable.export", [
 }
 
 //===----------------------------------------------------------------------===//
+// triton.dispatch operation
+//===----------------------------------------------------------------------===//
+
+// TODO(ezhulenev): Add support for dynamic shapes, so that we can eventually
+// lower to `flow.dispatch` with dynamic shapes.
+
+// TODO(ezhulenev): Do we need a function to convert workload into a 3D
+// workgroup (grid) similar to `flow.dispatch`? Current assumption is that
+// the end user provides grid dimension as a part of `triton.call`. We need to
+// revisit it later once we have more clear requirements.
+
+def TritonFlow_DispatchOp : TritonFlow_Op<"dispatch", [
+  AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+]> {
+  let summary = "a dispatch of Triton executable across a grid";
+
+  let description = [{
+    Dispatches Triton executable across a grid.
+  }];
+
+  let arguments = (ins
+    Variadic<Index>:$grid,
+    SymbolRefAttr:$entry_point,
+    Variadic<AnyType>:$arguments
+  );
+
+  let results = (outs
+    Variadic<AnyType>:$results
+  );
+
+  let assemblyFormat = [{
+    $entry_point
+      `[` $grid `]` ``
+      `(` $arguments `)`
+       attr-dict `:`
+       functional-type($arguments, $results)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // triton.call operation
 //===----------------------------------------------------------------------===//
+
+// TODO(ezhulenev): Add support for dynamic shapes, so that we can eventually
+// lower to `flow.dispatch` with dynamic shapes.
 
 def TritonFlow_CallOp : TritonFlow_Op<"call", [
     AttrSizedOperandSegments,
@@ -121,8 +165,8 @@ def TritonFlow_CallOp : TritonFlow_Op<"call", [
   }];
 
   let arguments = (ins
-    Variadic<TritonFlow_Dim>:$grid,
-    TritonFlow_FuncRefAttr:$callee,
+    Variadic<Index>:$grid,
+    FlatSymbolRefAttr:$callee,
     Variadic<AnyType>:$arguments
   );
 
@@ -139,4 +183,4 @@ def TritonFlow_CallOp : TritonFlow_Op<"call", [
   }];
 }
 
-#endif // TRITON_OPS
+#endif // TRITONFLOW_OPS

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/BUILD.bazel
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/BUILD.bazel
@@ -16,6 +16,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "invalid.mlir",
             "ops.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/CMakeLists.txt
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "invalid.mlir"
     "ops.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/invalid.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/invalid.mlir
@@ -15,7 +15,7 @@ triton.executable @foo {
 // -----
 
 triton.executable @foo {
-  // expected-error @+1 {{op refers to an unknown Triton function}}
+  // expected-error @+1 {{op refers to an unknown Triton function: @bar}}
   triton.executable.export @bar
   builtin.module {}
 }
@@ -23,7 +23,15 @@ triton.executable @foo {
 // -----
 
 func.func @main(%arg0: index) {
-  // expected-error @+1 {{op refers to an unknown Triton callee}}
+  // expected-error @+1 {{op refers to an unknown Triton entry point: @foo}}
+  triton.dispatch @foo[%arg0]() : () -> ()
+  return
+}
+
+// -----
+
+func.func @main(%arg0: index) {
+  // expected-error @+1 {{op refers to an unknown Triton function: @foo}}
   triton.call @foo[%arg0]() : () -> ()
   return
 }

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/invalid.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/invalid.mlir
@@ -1,0 +1,29 @@
+// RUN: iree-opt %s --iree-plugin=openxla-triton --split-input-file --verify-diagnostics
+
+// expected-error @+1 {{op expected exactly one inner builtin.module operation}}
+triton.executable @foo {
+}
+
+// -----
+
+// expected-error @+1 {{op expected exactly one inner builtin.module operation}}
+triton.executable @foo {
+  builtin.module {}
+  builtin.module {}
+}
+
+// -----
+
+triton.executable @foo {
+  // expected-error @+1 {{op refers to an unknown Triton function}}
+  triton.executable.export @bar
+  builtin.module {}
+}
+
+// -----
+
+func.func @main(%arg0: index) {
+  // expected-error @+1 {{op refers to an unknown Triton callee}}
+  triton.call @foo[%arg0]() : () -> ()
+  return
+}

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/ops.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/ops.mlir
@@ -29,6 +29,23 @@ triton.executable private @example {
 
 // -----
 
+triton.executable private @example {
+  triton.executable.export @compute
+  builtin.module {
+    func.func @compute(%arg0: !tt.ptr<f32>) { return }
+  }
+}
+
+func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
+  triton.dispatch @example::@compute[%arg0](%arg1) : (tensor<?xf32>) -> ()
+  return
+}
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
+// CHECK:   triton.dispatch @example::@compute[%arg0](%arg1)
+
+// -----
+
 func.func private @triton(%arg0: !tt.ptr<f32>) {
   return
 }

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/triton_to_flow_dispatch.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/triton_to_flow_dispatch.mlir
@@ -31,7 +31,7 @@ func.func @main(%arg0: tensor<128xf32>, %arg1: tensor<128xf32>) -> tensor<128xf3
   %grid = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%dim]
   %dim_i32 = arith.index_cast %dim : index to i32
 
-  %0 = triton.dispatch @add_kernel[%grid](%dim_i32, %arg0, %arg1)
+  %0 = triton.call @add_kernel[%grid](%dim_i32, %arg0, %arg1)
     : (i32, tensor<128xf32>, tensor<128xf32>) -> tensor<128xf32>
 
   return %0 : tensor<128xf32>

--- a/runtime/src/openxla/runtime/nvgpu/triton/test/triton_add_kernel.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/triton/test/triton_add_kernel.mlir
@@ -33,7 +33,7 @@ func.func @main(%arg0: tensor<128xf32>, %arg1: tensor<128xf32>) -> tensor<128xf3
   %grid = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%dim]
   %dim_i32 = arith.index_cast %dim : index to i32
 
-  %0 = triton.dispatch @add_kernel[%grid](%dim_i32, %arg0, %arg1)
+  %0 = triton.call @add_kernel[%grid](%dim_i32, %arg0, %arg1)
     : (i32, tensor<128xf32>, tensor<128xf32>) -> tensor<128xf32>
 
   return %0 : tensor<128xf32>


### PR DESCRIPTION
Also renamed `triton.dispatch` to `triton.call`. `TritonCallOp` will be the entry point into the Triton plugin, easy to use externally, and `triton.executable` + `triton.dispatch` will be an internal implementation detail.