### PR TITLE
Add dependency pins and update README with project maintenance steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,54 @@ Some of the tests can run only on an Ampere+ devices because they rely on the
 cmake --build build
 ctest --test-dir build -R openxla/runtime/nvgpu/cudnn/test/
 ```
+
+## Project Maintenance
+
+This section is a work in progress describing various project maintenance
+tasks.
+
+### Pre-requisite: Install openxla-devtools
+
+```
+pip install git+https://github.com/openxla/openxla-devtools.git
+```
+
+### Sync all deps to pinned versions
+
+```
+openxla-workspace sync
+```
+
+### Update IREE to head
+
+This updates the pinned IREE revision to the HEAD revision at the remote.
+
+```
+# Updates the sync_deps.py metadata.
+openxla-workspace roll iree
+# Brings all dependencies to pinned versions.
+openxla-workspace sync
+```
+
+### Full update of all deps
+
+This updates the pinned revisions of all dependencies. This is presently done
+by updating `openxla-pjrt-plugin` to remote HEAD and deriving the IREE
+dependency from its pin.
+
+```
+# Updates the sync_deps.py metadata.
+openxla-workspace roll nightly
+# Brings all dependencies to pinned versions.
+openxla-workspace sync
+```
+
+### Pin current versions of all deps
+
+This can be done if local, cross project changes have been made and landed.
+It snapshots the state of all deps as actually checked out and updates
+the metadata.
+
+```
+openxla-workspace pin
+```

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+### AUTO-GENERATED: DO NOT EDIT
+### Casual developers and CI bots invoke this to do the most
+### efficient checkout of dependencies.
+### Cross-repo project development should use the 
+### 'openxla-workspace' dev tool for more full featured setup.
+### Update with: openxla-workspace pin
+
+PINNED_VERSIONS = {
+  "iree": "910f12f87d0c10d0c56ddf5ab9bd3589e99eb05f",
+  "openxla-pjrt-plugin": "655be2bf9434b53695b8765f108b441a8bd45e42"
+}
+
+ORIGINS = {
+  "iree": "https://github.com/openxla/iree.git",
+  "openxla-pjrt-plugin": "https://github.com/openxla/openxla-pjrt-plugin.git"
+}
+
+SUBMODULES = {
+  "iree": 1
+}
+
+
+
+### Update support:
+
+import argparse
+from pathlib import Path
+import re
+import shlex
+import subprocess
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Source deps sync")
+  parser.add_argument(
+      "--exclude-submodule",
+      nargs="*",
+      help="Exclude submodules by regex (relative to '{project}:{path})")
+  parser.add_argument("--exclude-dep",
+                      nargs="*",
+                      help="Excludes dependencies by regex")
+  parser.add_argument("--depth",
+                      type=int,
+                      default=0,
+                      help="Fetch revisions with --depth")
+  parser.add_argument("--submodules-depth",
+                      type=int,
+                      default=0,
+                      help="Update submodules with --depth")
+  args = parser.parse_args()
+
+  workspace_dir = Path(__file__).resolve().parent.parent
+  for repo_name, revision in PINNED_VERSIONS.items():
+    # Exclude this dep?
+    exclude_repo = False
+    for exclude_pattern in (args.exclude_dep or ()):
+      if re.search(exclude_pattern, repo_name):
+        exclude_repo = True
+    if exclude_repo:
+      print(f"Excluding {repo_name} based on --exclude-dep")
+      continue
+
+    print(f"Syncing {repo_name}")
+    repo_dir = workspace_dir / repo_name
+    if not repo_dir.exists():
+      # Shallow clone
+      print(f"  Cloning {repo_name}...")
+      repo_dir.mkdir()
+      run(["init"], repo_dir)
+      run(["remote", "add", "origin", ORIGINS[repo_name]], repo_dir)
+    # Checkout detached head.
+    fetch_args = ["fetch"]
+    if args.depth > 0:
+      fetch_args.extend(["--depth=1"])
+    fetch_args.extend(["origin", revision])
+    run(fetch_args, repo_dir)
+    run(["-c", "advice.detachedHead=false", "checkout", revision], repo_dir)
+    if SUBMODULES.get(repo_name):
+      print(f"  Initializing submodules for {repo_name}")
+      cp = run(["submodule", "status"],
+               repo_dir,
+               silent=True,
+               capture_output=True)
+      submodules = []
+      for submodule_status_line in cp.stdout.decode().splitlines():
+        submodule_status_parts = submodule_status_line.split()
+        submodule_path = submodule_status_parts[1]
+        exclude_submodule = False
+        for exclude_pattern in (args.exclude_submodule or ()):
+          if re.search(exclude_pattern, f"{repo_name}:{submodule_path}"):
+            exclude_submodule = True
+        if exclude_submodule:
+          print(f"  Excluding {submodule_path} based on --exclude-submodule")
+          continue
+        submodules.append(submodule_path)
+
+      update_args = ["submodule", "update", "--init"]
+      if args.submodules_depth > 0:
+        update_args.extend(["--depth", "1"])
+      update_args.extend(["--"])
+      update_args.extend(submodules)
+      run(update_args, repo_dir)
+
+
+def run(args,
+        cwd,
+        *,
+        capture_output: bool = False,
+        check: bool = True,
+        silent: bool = False):
+  args = ["git"] + args
+  args_text = ' '.join([shlex.quote(arg) for arg in args])
+  if not silent:
+    print(f"  [{cwd}]$ {args_text}")
+  cp = subprocess.run(args, cwd=str(cwd), capture_output=capture_output)
+  if check and cp.returncode != 0:
+    addl_info = f":\n({cp.stderr.decode()})" if capture_output else ""
+    raise RuntimeError(f"Git command failed: {args_text} (from {cwd})"
+                       f"{addl_info}")
+  return cp
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
These pins just resolve to the 'nightly' rolling schedule to get started and may not build. Next step will be to bootstrap the CI off of them.