### PR TITLE
Build CUDNN graph on module initialization

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Conversion/ConvertHLOToCUDNN.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Conversion/ConvertHLOToCUDNN.cpp
@@ -149,7 +149,7 @@ static LogicalResult outlineToGraph(TensorValue result,
   // Replace root with cudnn.call op.
   rewriter.setInsertionPoint(root);
   auto loadedHandle = rewriter.create<IREE::Util::GlobalLoadOp>(
-      loc, rewriter.getType<HandleType>(), globalHandle.getSymNameAttr());
+      loc, handleTy, globalHandle.getSymNameAttr());
   rewriter.replaceOpWithNewOp<CallOp>(
       root, result.getType(), graph.getName(), loadedHandle,
       ArrayRef<Value>(arguments.begin(), arguments.size()));

--- a/compiler/src/openxla/compiler/nvgpu/Conversion/ConvertHLOToCUDNN.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Conversion/ConvertHLOToCUDNN.cpp
@@ -32,19 +32,21 @@ using TensorValue = TypedValue<TensorType>;
 
 static CudnnTensorType getCudnnTensorType(mlir::TensorType type,
                                           Layout layout) {
-  auto shape = [&]() -> SmallVector<int64_t> {
-    auto shape = type.getShape();
-    switch (layout) {
-      case Layout::NCHW:
-      case Layout::KCHW:
-        return {shape.begin(), shape.end()};
-      case Layout::NHWC:
-      case Layout::KHWC:
-        return {shape[0], shape[3], shape[1], shape[2]};
-    }
-    return {};
-  }();
-  return CudnnTensorType::get(shape, type.getElementType(), layout);
+  auto shape = type.getShape();
+  assert(shape.size() == 4);
+  SmallVector<int64_t> newShape;
+  switch (layout) {
+    case Layout::NCHW:
+    case Layout::KCHW:
+      newShape = {shape.begin(), shape.end()};
+      break;
+    case Layout::NHWC:
+    case Layout::KHWC:
+      newShape = {shape[0], shape[3], shape[1], shape[2]};
+      break;
+  }
+  assert(newShape.size() == shape.size());
+  return CudnnTensorType::get(newShape, type.getElementType(), layout);
 }
 
 static FailureOr<Layout> getCudnnTensorLayout(int64_t batchDim,
@@ -81,6 +83,10 @@ static LogicalResult outlineToGraph(TensorValue result,
     return rewriter.notifyMatchFailure(result.getLoc(), "expected one result");
   func::FuncOp func = root->getParentOfType<func::FuncOp>();
   if (!func) return rewriter.notifyMatchFailure(root, "expected child of func");
+  ModuleOp m = func->getParentOfType<ModuleOp>();
+  if (!m)
+    return rewriter.notifyMatchFailure(root,
+                                       "expected child of func in module");
 
   // Collect the set of ops to clone into the region.
   SetVector<Operation*> ops;
@@ -98,17 +104,16 @@ static LogicalResult outlineToGraph(TensorValue result,
   }
 
   // Create the cudnn.graph op with an empty region.
-  OpBuilder::InsertionGuard guard(rewriter);
+  SymbolTable symbolTable(func->getParentOp());
   rewriter.setInsertionPoint(func);
   GraphOp graph = rewriter.create<GraphOp>(root->getLoc(), funcType,
                                            /*arg_attrs=*/ArrayAttr{},
                                            /*res_attrs=*/ArrayAttr{});
-  SymbolTable symtab(func->getParentOp());
   graph.setName(root->getName().getStringRef());
-  symtab.insert(graph);
+  symbolTable.insert(graph);
 
   // Clone ops into region.
-  rewriter.setInsertionPointToEnd(graph.addEntryBlock());
+  rewriter.setInsertionPointToStart(graph.addEntryBlock());
   IRMapping mapping;
   for (size_t index = 0; index < arguments.size(); ++index) {
     Value arg = arguments[index];
@@ -125,14 +130,29 @@ static LogicalResult outlineToGraph(TensorValue result,
       result.getLoc(), funcType.getResults(), results);
   rewriter.create<ReturnOp>(root->getLoc(), castOp.getResults());
 
+  // Create global handle before any other initialization.
+  rewriter.setInsertionPointToStart(m.getBody());
+  Location loc = root->getLoc();
+  std::string globalHandleName = (graph.getName() + ".handle").str();
+  auto handleTy = rewriter.getType<HandleType>();
+  auto globalHandle = rewriter.create<IREE::Util::GlobalOp>(
+      loc, globalHandleName, /*isMutable=*/false, handleTy);
+
+  // Create global handle initializer.
+  auto initializer = rewriter.create<IREE::Util::InitializerOp>(loc);
+  rewriter.setInsertionPointToStart(initializer.addEntryBlock());
+  auto device = rewriter.create<IREE::HAL::ExSharedDeviceOp>(loc);
+  auto handle = rewriter.create<HandleOp>(loc, device);
+  rewriter.create<IREE::Util::GlobalStoreOp>(loc, handle, globalHandle);
+  rewriter.create<IREE::Util::InitializerReturnOp>(loc);
+
   // Replace root with cudnn.call op.
   rewriter.setInsertionPoint(root);
-  auto device = rewriter.create<IREE::HAL::ExSharedDeviceOp>(root->getLoc());
-  auto handle = rewriter.create<HandleOp>(root->getLoc(), device.getResult());
+  auto loadedHandle = rewriter.create<IREE::Util::GlobalLoadOp>(
+      loc, rewriter.getType<HandleType>(), globalHandle.getSymNameAttr());
   rewriter.replaceOpWithNewOp<CallOp>(
-      root, result.getType(), graph.getName(), handle,
+      root, result.getType(), graph.getName(), loadedHandle,
       ArrayRef<Value>(arguments.begin(), arguments.size()));
-
   return success();
 }
 

--- a/compiler/src/openxla/compiler/nvgpu/Transforms/test/hlo_to_cudnn.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Transforms/test/hlo_to_cudnn.mlir
@@ -3,130 +3,136 @@
 // RUN: | FileCheck %s
 
 
-// CHECK:      cudnn.graph @stablehlo.clamp(
-// CHECK-SAME:   %[[ARGUMENT:.*]]: !cudnn.tensor<1x16x32x8xf32, NCHW>
-// CHECK-SAME: ) -> !cudnn.tensor<1x16x32x8xf32, NCHW> {
-// CHECK:        %[[RESULT:.*]] = cudnn.relu(%[[ARGUMENT]]) type = f32 lower_clip = 0.000000e+00
-// CHECK-SAME      : (!cudnn.tensor<1x16x32x8xf32, NCHW>) -> !cudnn.tensor<1x16x32x8xf32, NCHW>
-// CHECK:        cudnn.return %[[RESULT]]
-
-// CHECK: @test_relu(%[[ARGUMENT]]: tensor<1x16x32x8xf32>)
-func.func @test_relu(%argument: tensor<1x16x32x8xf32>) -> tensor<1x16x32x8xf32> {
-  // CHECK: %[[DEVICE:.*]] = hal.ex.shared_device
-  // CHECK: %[[HANDLE:.*]] = cudnn.handle(%[[DEVICE]])
-  // CHECK: %[[CALL:.*]] = cudnn.call handle(%[[HANDLE]]) @stablehlo.clamp(%[[ARGUMENT]])
-  // CHECK: return %[[CALL]]
+func.func @test_relu(%argument: tensor<1x16x32x8xf32>)
+    -> tensor<1x16x32x8xf32> {
   %min = stablehlo.constant dense<0.0> : tensor<1x16x32x8xf32>
   %max = stablehlo.constant dense<0xFFFFFFFF> : tensor<1x16x32x8xf32>
   %result = stablehlo.clamp %min, %argument, %max : tensor<1x16x32x8xf32>
   return %result : tensor<1x16x32x8xf32>
 }
 
+// CHECK:      util.global public @stablehlo.clamp.handle
+// CHECK:      util.initializer
+// CHECK:        %[[DEVICE:.*]] = hal.ex.shared_device
+// CHECK:        %[[HANDLE:.*]] = cudnn.handle(%[[DEVICE]])
+// CHECK:        util.global.store %[[HANDLE]], @stablehlo.clamp.handle
+// CHECK:        util.initializer.return
+
+// CHECK:      cudnn.graph @stablehlo.clamp(%[[ARG0:.*]]: !cudnn.tensor<1x16x32x8xf32, NCHW>)
+// CHECK-SAME:     -> !cudnn.tensor<1x16x32x8xf32, NCHW>
+// CHECK:        %[[RELU:.*]] = cudnn.relu(%[[ARG0]])
+// CHECK-SAME:       type = f32 lower_clip = 0.000000e+00
+// CHECK:        cudnn.return %[[RELU]]
+
+// CHECK:      @test_relu(%[[ARG0]]: tensor<1x16x32x8xf32>)
+// CHECK:        %[[STABLEHLO:.*]].clamp.handle = util.global.load @stablehlo.clamp.handle
+// CHECK:        %[[CALL:.*]] = cudnn.call handle(%[[STABLEHLO]].clamp.handle) @stablehlo.clamp(%[[ARG0]])
+// CHECK:        return %[[CALL]]
+
 // -----
 
-// CHECK:      cudnn.graph @stablehlo.convolution(
-// CHECK-SAME:   %[[INPUT:.*]]: !cudnn.tensor<100x32x26x26xf32, NCHW>,
-// CHECK-SAME:   %[[FILTER:.*]]: !cudnn.tensor<1x32x3x3xf32, NCHW>
-// CHECK-SAME: ) -> !cudnn.tensor<100x1x28x28xf32, NCHW> {
-// CHECK:        %[[RESULT:.*]] = cudnn.convolution(%[[INPUT]], %[[FILTER]])
-// CHECK-SAME:   alpha = 1.000000e+00 beta = 0.000000e+00
-// CHECK-SAME:   spatial_dim_count = 2
-// CHECK-SAME:   spatial_stride = [1, 1]
-// CHECK-SAME:   pre_padding = [2, 2]
-// CHECK-SAME:   post_padding = [2, 2]
-// CHECK-SAME:   dilation = [1, 1] : (
-// CHECK-SAME:       !cudnn.tensor<100x32x26x26xf32, NCHW>,
-// CHECK-SAME:       !cudnn.tensor<1x32x3x3xf32, NCHW>
-// CHECK-SAME:     ) -> !cudnn.tensor<100x1x28x28xf32, NCHW>
-// CHECK:        cudnn.return %[[RESULT]]
-
-// CHECK:      @test_conv(
-// CHECK-SAME:   %[[INPUT]]: tensor<100x32x26x26xf32>,
-// CHECK-SAME:   %[[FILTER]]: tensor<1x32x3x3xf32>
-// CHECK-SAME: ) -> tensor<100x1x28x28xf32> {
-func.func @test_conv(
-  %input : tensor<100x32x26x26xf32>,
-  %filter : tensor<1x32x3x3xf32>
-) -> tensor<100x1x28x28xf32> {
-  // CHECK: %[[DEVICE_0:.*]] = hal.ex.shared_device
-  // CHECK: %[[HANDLE_0:.*]] = cudnn.handle(%[[DEVICE_0]])
-  // CHECK: %[[CALL_0:.*]] = cudnn.call handle(%[[HANDLE_0]]) @stablehlo.convolution(%[[INPUT]], %[[FILTER]])
-  // CHECK: return %[[CALL_0]]
+func.func @test_conv(%input : tensor<100x32x26x26xf32>,
+    %filter : tensor<1x32x3x3xf32>) -> tensor<100x1x28x28xf32> {
   %result = "stablehlo.convolution"(%input, %filter) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 1,
-      input_spatial_dimensions = [2, 3],
-      kernel_input_feature_dimension = 1,
-      kernel_output_feature_dimension = 0,
-      kernel_spatial_dimensions = [2, 3],
-      output_batch_dimension = 0,
-      output_feature_dimension = 1,
-      output_spatial_dimensions = [2, 3]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x32x26x26xf32>, tensor<1x32x3x3xf32>) -> tensor<100x1x28x28xf32>
+      batch_group_count = 1 : i64,
+      dimension_numbers = #stablehlo.conv<raw
+        input_batch_dimension = 0,
+        input_feature_dimension = 1,
+        input_spatial_dimensions = [2, 3],
+        kernel_input_feature_dimension = 1,
+        kernel_output_feature_dimension = 0,
+        kernel_spatial_dimensions = [2, 3],
+        output_batch_dimension = 0,
+        output_feature_dimension = 1,
+        output_spatial_dimensions = [2, 3]>,
+      feature_group_count = 1 : i64,
+      lhs_dilation = dense<1> : tensor<2xi64>,
+      padding = dense<2> : tensor<2x2xi64>,
+      rhs_dilation = dense<1> : tensor<2xi64>,
+      window_strides = dense<1> : tensor<2xi64>}
+      : (tensor<100x32x26x26xf32>, tensor<1x32x3x3xf32>)
+      -> tensor<100x1x28x28xf32>
   func.return %result : tensor<100x1x28x28xf32>
 }
 
+// CHECK:        util.global public @stablehlo.convolution.handle
+// CHECK:        util.initializer
+// CHECK:          %[[DEVICE_0:.*]] = hal.ex.shared_device
+// CHECK:          %[[HANDLE_0:.*]] = cudnn.handle(%[[DEVICE_0]])
+// CHECK:          util.global.store %[[HANDLE_0]], @stablehlo.convolution.handle
+// CHECK:          util.initializer.return
+
+// CHECK:        cudnn.graph @stablehlo.convolution(%[[ARG0_0:.*]]: !cudnn.tensor<100x32x26x26xf32, NCHW>, %[[ARG1:.*]]: !cudnn.tensor<1x32x3x3xf32, NCHW>)
+// CHECK-SAME:       -> !cudnn.tensor<100x1x28x28xf32, NCHW>
+// CHECK:          %[[CONVOLUTION:.*]] = cudnn.convolution(%[[ARG0_0]], %[[ARG1]])
+// CHECK-SAME:         alpha = 1.000000e+00
+// CHECK-SAME:         beta = 0.000000e+00
+// CHECK-SAME:         spatial_dim_count = 2
+// CHECK-SAME:         spatial_stride = [1, 1]
+// CHECK-SAME:         pre_padding = [2, 2]
+// CHECK-SAME:         post_padding = [2, 2]
+// CHECK-SAME:         dilation = [1, 1]
+// CHECK:          cudnn.return %[[CONVOLUTION]]
+
+// CHECK:        @test_conv(%[[ARG0_0]]: tensor<100x32x26x26xf32>, %[[ARG1]]: tensor<1x32x3x3xf32>)
+// CHECK:          %[[STABLEHLO_0:.*]].convolution.handle = util.global.load @stablehlo.convolution.handle
+// CHECK:          %[[CALL_0:.*]] = cudnn.call handle(%[[STABLEHLO_0]].convolution.handle) @stablehlo.convolution(%[[ARG0_0]], %[[ARG1]])
+// CHECK:          return %[[CALL_0]]
+
 // -----
 
-// CHECK:      cudnn.graph @stablehlo.clamp(
-// CHECK-SAME:   %[[INPUT]]: !cudnn.tensor<100x32x26x26xf32, NHWC>,
-// CHECK-SAME:   %[[FILTER:.*]]: !cudnn.tensor<1x32x3x3xf32, NHWC>
-// CHECK-SAME: ) -> !cudnn.tensor<100x1x28x28xf32, NHWC> {
-// CHECK:        %[[CONV:.*]] = cudnn.convolution(%[[INPUT]], %[[FILTER]])
-// CHECK-SAME:     alpha = 1.000000e+00 beta = 0.000000e+00
-// CHECK-SAME:     spatial_dim_count = 2
-// CHECK-SAME:     spatial_stride = [1, 1]
-// CHECK-SAME:     pre_padding = [2, 2]
-// CHECK-SAME:     post_padding = [2, 2]
-// CHECK-SAME:     dilation = [1, 1] : (
-// CHECK-SAME:       !cudnn.tensor<100x32x26x26xf32, NHWC>,
-// CHECK-SAME:       !cudnn.tensor<1x32x3x3xf32, NHWC>
-// CHECK-SAME:     ) -> !cudnn.tensor<100x1x28x28xf32, NHWC>
-// CHECK:        %[[RESULT:.*]] = cudnn.relu(%[[CONV]]) type = f32 lower_clip = 0.000000e+00
-// CHECK-SAME:     : (!cudnn.tensor<100x1x28x28xf32, NHWC>) -> !cudnn.tensor<100x1x28x28xf32, NHWC>
-// CHECK:        cudnn.return %[[RESULT]]
-
-// CHECK:      @test_graph(
-// CHECK-SAME:   %[[INPUT]]: tensor<100x26x26x32xf32>,
-// CHECK-SAME:   %[[FILTER]]: tensor<1x3x3x32xf32>
-// CHECK-SAME: ) -> tensor<100x28x28x1xf32> {
 func.func @test_graph(
   %input : tensor<100x26x26x32xf32>,
   %filter : tensor<1x3x3x32xf32>
 ) -> tensor<100x28x28x1xf32> {
-  // CHECK: %[[DEVICE:.*]] = hal.ex.shared_device
-  // CHECK: %[[HANDLE:.*]] = cudnn.handle(%[[DEVICE]])
-  // CHECK: %[[CALL:.*]] = cudnn.call handle(%[[HANDLE]]) @stablehlo.clamp(%[[INPUT]], %[[FILTER]])
-  // CHECK: return %[[CALL_0]]
   %conv = "stablehlo.convolution"(%input, %filter) {
-    batch_group_count = 1 : i64,
-    dimension_numbers = #stablehlo.conv<raw
-      input_batch_dimension = 0,
-      input_feature_dimension = 3,
-      input_spatial_dimensions = [1, 2],
-      kernel_input_feature_dimension = 3,
-      kernel_output_feature_dimension = 0,
-      kernel_spatial_dimensions = [1, 2],
-      output_batch_dimension = 0,
-      output_feature_dimension = 3,
-      output_spatial_dimensions = [1, 2]
-    >,
-    feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
-  } : (tensor<100x26x26x32xf32>, tensor<1x3x3x32xf32>) -> tensor<100x28x28x1xf32>
+      batch_group_count = 1 : i64,
+      dimension_numbers = #stablehlo.conv<raw
+        input_batch_dimension = 0,
+        input_feature_dimension = 3,
+        input_spatial_dimensions = [1, 2],
+        kernel_input_feature_dimension = 3,
+        kernel_output_feature_dimension = 0,
+        kernel_spatial_dimensions = [1, 2],
+        output_batch_dimension = 0,
+        output_feature_dimension = 3,
+        output_spatial_dimensions = [1, 2]>,
+      feature_group_count = 1 : i64,
+      lhs_dilation = dense<1> : tensor<2xi64>,
+      padding = dense<2> : tensor<2x2xi64>,
+      rhs_dilation = dense<1> : tensor<2xi64>,
+      window_strides = dense<1> : tensor<2xi64>}
+      : (tensor<100x26x26x32xf32>, tensor<1x3x3x32xf32>)
+      -> tensor<100x28x28x1xf32>
   %min = stablehlo.constant dense<0.0> : tensor<100x28x28x1xf32>
   %max = stablehlo.constant dense<0xFFFFFFFF> : tensor<100x28x28x1xf32>
   %result = stablehlo.clamp %min, %conv, %max : tensor<100x28x28x1xf32>
   func.return %result : tensor<100x28x28x1xf32>
 }
+
+// CHECK:        util.global public @stablehlo.clamp.handle
+// CHECK:        util.initializer
+// CHECK:          %[[DEVICE_1:.*]] = hal.ex.shared_device
+// CHECK:          %[[HANDLE_1:.*]] = cudnn.handle(%[[DEVICE_1]])
+// CHECK:          util.global.store %[[HANDLE_1]], @stablehlo.clamp.handle
+// CHECK:          util.initializer.return
+
+// CHECK:        cudnn.graph @stablehlo.clamp(%[[ARG0_1:.*]]: !cudnn.tensor<100x32x26x26xf32, NHWC>, %[[ARG1_0:.*]]: !cudnn.tensor<1x32x3x3xf32, NHWC>)
+// CHECK-SAME:       -> !cudnn.tensor<100x1x28x28xf32, NHWC>
+// CHECK:          %[[CONVOLUTION_0:.*]] = cudnn.convolution(%[[ARG0_1]], %[[ARG1_0]])
+// CHECK-SAME:         alpha = 1.000000e+00
+// CHECK-SAME:         beta = 0.000000e+00
+// CHECK-SAME:         spatial_dim_count = 2
+// CHECK-SAME:         spatial_stride = [1, 1]
+// CHECK-SAME:         pre_padding = [2, 2]
+// CHECK-SAME:         post_padding = [2, 2]
+// CHECK-SAME:         dilation = [1, 1]
+// CHECK:          %[[RELU_0:.*]] = cudnn.relu(%[[CONVOLUTION_0]])
+// CHECK-SAME:         type = f32
+// CHECK-SAME:         lower_clip = 0.000000e+00
+// CHECK:          cudnn.return %[[RELU_0]]
+
+// CHECK:        @test_graph(%[[ARG0_1]]: tensor<100x26x26x32xf32>, %[[ARG1_0]]: tensor<1x3x3x32xf32>)
+// CHECK:          %[[STABLEHLO_1:.*]].clamp.handle = util.global.load @stablehlo.clamp.handle
+// CHECK:          %[[CALL_1:.*]] = cudnn.call handle(%[[STABLEHLO_1]].clamp.handle) @stablehlo.clamp(%[[ARG0_1]], %[[ARG1_0]])
+// CHECK:          return %[[CALL_1]]

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/e2e_conv2d.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/e2e_conv2d.mlir
@@ -3,22 +3,19 @@
 // RUN:     --mlir-print-ir-after=openxla-nvgpu-convert-cudnn-to-runtime       \
 // RUN:     2> %t-ir                                                           \
 // RUN: | iree-run-module --module=- --device=cuda --function=test_conv        \
+// RUN:     --input=100x26x26x32xf32=1.0 --input=64x3x3x32xf32=1.0             \
 // RUN: | FileCheck %s
 
 // RUN: cat %t-ir                                                              \
 // RUN: | FileCheck %s --check-prefix=CHECK-IR
 
 
-util.global @x : tensor<100x26x26x32xf32> = dense<1.0> : tensor<100x26x26x32xf32>
-util.global @w : tensor<64x3x3x32xf32> = dense<1.0> : tensor<64x3x3x32xf32>
-
 // CHECK: @test_conv
 // CHECK: 100x26x26x64xf32
 // CHECK: [128 128 128 128 128
 // CHECK: [192 192 192 192 192
-func.func @test_conv() -> tensor<100x26x26x64xf32> {
-  %x = util.global.load @x : tensor<100x26x26x32xf32>
-  %w = util.global.load @w : tensor<64x3x3x32xf32>
+func.func @test_conv(%x : tensor<100x26x26x32xf32>, %w : tensor<64x3x3x32xf32>)
+    -> tensor<100x26x26x64xf32> {
   %result = "stablehlo.convolution"(%x, %w) {
       batch_group_count = 1 : i64,
       dimension_numbers = #stablehlo.conv<raw
@@ -45,14 +42,22 @@ func.func @test_conv() -> tensor<100x26x26x64xf32> {
 // Ensure that we actually lower to Cudnn.
 // CHECK-IR: IR Dump After ConvertCudnnToRuntime (openxla-nvgpu-convert-cudnn-to-runtime)
 
+// CHECK-IR: util.initializer
+// CHECK-IR:   hal.ex.shared_device
+// CHECK-IR:   func.call @cudnn.handle
+
 // CHECK-IR: func.func @stablehlo.convolution.builder
-// CHECK-IR:   call @cudnn.tensor.create.4d.nhwc
-// CHECK-IR:   call @cudnn.tensor.create.4d.nhwc
-// CHECK-IR:   call @cudnn.convolution.2d
-// CHECK-IR:   call @cudnn.operation_graph.create
+// CHECK-IR:   %0 = call @cudnn.tensor.create.4d.nhwc
+// CHECK-IR:   %1 = call @cudnn.tensor.create.4d.nhwc
+// CHECK-IR:   %2 = call @cudnn.convolution.2d
+// CHECK-IR:   %3 = call @cudnn.operation_graph.create
+
+// CHECK-IR: util.initializer
+// CHECK-IR:   func.call @stablehlo.convolution.builder
+// CHECK-IR:   func.call @cudnn.executable.create
+// CHECK-IR:   util.global.store
 
 // CHECK-IR: func.func private @_test_conv
-// CHECK-IR:   call @cudnn.handle
-// CHECK-IR:   call @stablehlo.convolution.builder
-// CHECK-IR:   call @cudnn.executable.create
+// CHECK-IR:   util.global.load
+// CHECK-IR:   util.global.load
 // CHECK-IR:   call @cudnn.execute.2

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/e2e_resnet50_subset.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/e2e_resnet50_subset.mlir
@@ -88,14 +88,21 @@ func.func @predict(%arg0: tensor<1x56x56x64xf32>) -> tensor<1x56x56x256xf32>
 // Ensure that we actually lower to Cudnn.
 // CHECK-IR: IR Dump After ConvertCudnnToRuntime (openxla-nvgpu-convert-cudnn-to-runtime)
 
+// CHECK-IR: util.initializer
+// CHECK-IR:   hal.ex.shared_device
+// CHECK-IR:   func.call @cudnn.handle
+
 // CHECK-IR: func.func @stablehlo.convolution.builder
 // CHECK-IR:   call @cudnn.tensor.create.4d.nhwc
 // CHECK-IR:   call @cudnn.tensor.create.4d.nhwc
 // CHECK-IR:   call @cudnn.convolution.2d
 // CHECK-IR:   call @cudnn.operation_graph.create
 
+// CHECK-IR: util.initializer
+// CHECK-IR:   func.call @stablehlo.convolution.builder
+// CHECK-IR:   func.call @cudnn.executable.create
+
 // CHECK-IR: func.func private @_predict
-// CHECK-IR:   call @cudnn.handle
-// CHECK-IR:   call @stablehlo.convolution.builder
-// CHECK-IR:   call @cudnn.executable.create
+// CHECK-IR:   util.global.load
+// CHECK-IR:   util.global.load
 // CHECK-IR:   call @cudnn.execute.2


### PR DESCRIPTION
With CUDNN we are now ~6x faster than codegen for a single convolution. Measured 0.104 ms with CUDNN vs 0.671 ms w/o CUDNN on NVIDIA RTX A6000.