### PR TITLE
[Triton] Add support for outlining Triton calls with tied results

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.cpp
@@ -127,7 +127,7 @@ static LogicalResult verifyTritonFunction(
     return op->emitOpError() << "expected triton function with no results";
   }
 
-  // All triton call-like operation use tried results.
+  // All triton call-like operation use tied results.
   auto tiedOp = cast<IREE::Util::TiedOpInterface>(op);
   auto isTiedResult = [&](Value result) {
     return tiedOp.getTiedResultOperand(result);
@@ -149,7 +149,7 @@ static LogicalResult verifyTritonFunction(
   auto tritonInputs = tritonFunctionType.getInputs();
 
   // Collect results that are not tied to arguments, we'll need them later to
-  // check agains triton function type.
+  // check against triton function type.
   SmallVector<Type> untiedRets;
   SmallVector<int64_t> untiedIdxs;
   for (auto indexed : llvm::enumerate(rets)) {

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.cpp
@@ -6,6 +6,8 @@
 
 #include "openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.h"
 
+#include <functional>
+
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "llvm/ADT/STLExtras.h"
@@ -19,6 +21,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Types.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/Support/LogicalResult.h"
 #include "openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowDialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -54,8 +57,8 @@ static LogicalResult verifyArgumentTypes(Operation *op, TypeRange tritonArgs,
   for (auto pair : llvm::enumerate(llvm::zip_equal(tritonArgs, args))) {
     auto [tritonArgType, argType] = pair.value();
 
-    int64_t index = offset + pair.index();
     int64_t tritonIndex = tritonOffset + pair.index();
+    int64_t index = offset + pair.index();
 
     // Pointer arguments must be passed as tensors.
     if (auto ptr = tritonArgType.dyn_cast<triton::PointerType>()) {
@@ -88,21 +91,21 @@ static LogicalResult verifyArgumentTypes(Operation *op, TypeRange tritonArgs,
 
 static LogicalResult verifyResultTypes(Operation *op, TypeRange tritonRets,
                                        int64_t tritonOffset, TypeRange rets,
-                                       size_t offset = 0) {
+                                       ArrayRef<int64_t> retIdxs) {
   for (auto pair : llvm::enumerate(llvm::zip_equal(tritonRets, rets))) {
-    auto [tritonArgType, argType] = pair.value();
+    auto [tritonRetType, retType] = pair.value();
 
-    int64_t index = offset + pair.index();
     int64_t tritonIndex = tritonOffset + pair.index();
+    int64_t index = retIdxs[pair.index()];
 
     // Results passed to Triton kernels as destination buffers.
-    if (auto ptr = tritonArgType.dyn_cast<triton::PointerType>()) {
-      auto tensor = argType.dyn_cast<RankedTensorType>();
+    if (auto ptr = tritonRetType.dyn_cast<triton::PointerType>()) {
+      auto tensor = retType.dyn_cast<RankedTensorType>();
       if (!tensor)
         return op->emitOpError()
                << "result #" << index
                << " must be a tensor matching Triton pointer type at #"
-               << tritonIndex << " (" << argType << " vs " << ptr << ")";
+               << tritonIndex << " (" << retType << " vs " << ptr << ")";
 
       if (ptr.getPointeeType() != tensor.getElementType())
         return op->emitOpError()
@@ -117,15 +120,25 @@ static LogicalResult verifyResultTypes(Operation *op, TypeRange tritonRets,
 }
 
 static LogicalResult verifyTritonFunction(
-    Operation *op, FunctionType tritonFunctionType, TypeRange args,
-    TypeRange rets, IREE::HAL::PipelineLayoutAttr layout = {}) {
+    Operation *op, FunctionType tritonFunctionType, ValueRange args,
+    ValueRange rets, IREE::HAL::PipelineLayoutAttr layout = {}) {
   // We don't expect Triton functions returning any results at all.
   if (tritonFunctionType.getNumResults() != 0) {
     return op->emitOpError() << "expected triton function with no results";
   }
 
+  // All triton call-like operation use tried results.
+  auto tiedOp = cast<IREE::Util::TiedOpInterface>(op);
+  auto isTiedResult = [&](Value result) {
+    return tiedOp.getTiedResultOperand(result);
+  };
+
+  // Number of result tensors tied to one of the arguments.
+  size_t numTiedResults = llvm::count_if(rets, isTiedResult);
+  size_t numUntiedResults = llvm::count_if(rets, std::not_fn(isTiedResult));
+
   // Triton functions use "destination-passing style" for buffer outputs.
-  size_t expectedTritonArgs = args.size() + rets.size();
+  size_t expectedTritonArgs = args.size() + rets.size() - numTiedResults;
   if (tritonFunctionType.getNumInputs() != expectedTritonArgs) {
     return op->emitOpError()
            << "expected triton function with " << expectedTritonArgs
@@ -135,14 +148,25 @@ static LogicalResult verifyTritonFunction(
 
   auto tritonInputs = tritonFunctionType.getInputs();
 
+  // Collect results that are not tied to arguments, we'll need them later to
+  // check agains triton function type.
+  SmallVector<Type> untiedRets;
+  SmallVector<int64_t> untiedIdxs;
+  for (auto indexed : llvm::enumerate(rets)) {
+    if (isTiedResult(indexed.value())) continue;
+    untiedRets.push_back(indexed.value().getType());
+    untiedIdxs.push_back(indexed.index());
+  }
+
   if (!layout) {
     // If we do not have a layout, we should check Triton function signature
     // directly against the call operation arguments and results.
     auto tritonArgs = tritonInputs.take_front(args.size());
     auto tritonRets = tritonInputs.drop_front(args.size());
 
-    if (failed(verifyArgumentTypes(op, tritonArgs, 0, args)) ||
-        failed(verifyResultTypes(op, tritonRets, args.size(), rets)))
+    if (failed(verifyArgumentTypes(op, tritonArgs, /*tritonOffset=*/0, args)) ||
+        failed(verifyResultTypes(op, tritonRets, /*tritonOffset=*/args.size(),
+                                 untiedRets, /*retIdxs=*/untiedIdxs)))
       return failure();
 
   } else {
@@ -151,27 +175,28 @@ static LogicalResult verifyTritonFunction(
     auto numConstants = layout.getPushConstants();
     auto numBindings = layout.getSetLayouts().front().getBindings().size();
 
-    auto numBufArgs = numBindings - rets.size();
+    auto numPtrArgs = numBindings - numUntiedResults;
 
-    {  // Check buffer arguments.
-      auto bufs0 = tritonInputs.take_front(numBufArgs);
-      auto bufs1 = args.take_front(bufs0.size());
-      if (failed(verifyArgumentTypes(op, bufs0, /*tritonOffset=*/0, bufs1)))
+    {  // Check pointer arguments (passed as tensors)
+      auto ptrs0 = tritonInputs.take_front(numPtrArgs);
+      auto ptrs1 = args.take_front(ptrs0.size());
+      if (failed(verifyArgumentTypes(op, ptrs0, /*tritonOffset=*/0, ptrs1)))
         return failure();
     }
 
-    {  // Check constant (scalar) arguments.
+    {  // Check constant arguments (passed as scalar values)
       auto csts0 = tritonInputs.drop_front(numBindings);
-      auto csts1 = args.drop_front(numBufArgs).take_front(numConstants);
+      auto csts1 = args.drop_front(numPtrArgs).take_front(numConstants);
       if (failed(verifyArgumentTypes(op, csts0, /*tritonOffset=*/numBindings,
-                                     csts1, /*offset=*/numBufArgs)))
+                                     csts1, /*offset=*/numPtrArgs)))
         return failure();
     }
 
-    {  // Check results (result buffer destinations).
-      auto rets0 = tritonInputs.drop_front(numBufArgs).take_front(rets.size());
-      if (failed(verifyResultTypes(op, rets0,
-                                   /*tritonOffset=*/numBufArgs, rets)))
+    {  // Check results (defined as tensor results)
+      auto rets0 =
+          tritonInputs.drop_front(numPtrArgs).take_front(numUntiedResults);
+      if (failed(verifyResultTypes(op, rets0, /*tritonOffset=*/numPtrArgs,
+                                   untiedRets, /*retIdxs=*/untiedIdxs)))
         return failure();
     }
   }
@@ -273,9 +298,9 @@ LogicalResult DispatchOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // so it only means that it was already lowered to LLVM and we skip verifier.
   if (!tritonFunc) return success();
 
-  // Check that Triton function is compatible with the call arguments.
+  // Check that Triton function is compatible with the dispatch arguments.
   if (failed(verifyTritonFunction(getOperation(), tritonFunc.getFunctionType(),
-                                  getArguments().getTypes(), getResultTypes(),
+                                  getArguments(), getResults(),
                                   exportOp.getLayout()))) {
     return failure();
   }
@@ -324,8 +349,7 @@ LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   // Check that Triton function is compatible with the call arguments.
   if (failed(verifyTritonFunction(getOperation(), tritonFunc.getFunctionType(),
-                                  getArguments().getTypes(),
-                                  getResultTypes()))) {
+                                  getArguments(), getResults()))) {
     return failure();
   }
 

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/invalid.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/invalid.mlir
@@ -25,6 +25,25 @@ triton.executable @foo {
 
 // -----
 
+#pipeline_layout = #hal.pipeline.layout<push_constants = 1,
+  sets = [<0, bindings = [<0, storage_buffer, ReadOnly>,
+                          <1, storage_buffer>]>]>
+
+triton.executable @foo {
+  triton.executable.export @bar layout(#pipeline_layout)
+  builtin.module {
+    tt.func private @bar(!tt.ptr<f32>, !tt.ptr<i32>)
+  }
+}
+
+func.func @main(%arg0: index, %arg1: tensor<f32>) {
+  // expected-error @+1 {{op result #1 element type must match a Triton pointer type at #1 ('f32' vs 'i32')}}
+  triton.dispatch @foo::@bar[%arg0](%arg1) : (tensor<f32>) -> (%arg1, tensor<f32>)
+  return
+}
+
+// -----
+
 func.func @main(%arg0: index) {
   // expected-error @+1 {{op refers to an unknown Triton entry point: @foo}}
   triton.dispatch @foo[%arg0]() : () -> ()
@@ -56,5 +75,15 @@ tt.func private @foo(!tt.ptr<f32>)
 func.func @main(%arg0: index) {
   // expected-error @+1 {{op result #0 element type must match a Triton pointer type at #0 ('i32' vs 'f32')}}
   triton.call @foo[%arg0]() : () -> tensor<i32>
+  return
+}
+
+// -----
+
+tt.func private @foo(!tt.ptr<f32>, !tt.ptr<i32>)
+
+func.func @main(%arg0: index, %arg1: tensor<f32>) {
+  // expected-error @+1 {{op result #1 element type must match a Triton pointer type at #1 ('f32' vs 'i32')}}
+  triton.call @foo[%arg0](%arg1) : (tensor<f32>) -> (%arg1, tensor<f32>)
   return
 }

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/ops.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/test/ops.mlir
@@ -68,17 +68,36 @@ triton.executable private @example {
 }
 
 func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
-  %c0 = arith.constant 0 : index
-  %d0 = tensor.dim %arg1, %c0 : tensor<?xf32>
-  triton.dispatch @example::@compute[%arg0](%arg1) : (tensor<?xf32>{%d0}) -> ()
+  triton.dispatch @example::@compute[%arg0](%arg1)
+    : (tensor<?xf32>{%arg0}) -> ()
   return
 }
 
 // CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
-// CHECK:   %[[C0:.*]] = arith.constant 0 : index
-// CHECK:   %[[D0:.*]] = tensor.dim %[[ARG1]], %[[C0]] : tensor<?xf32>
-// CHECK:   triton.dispatch @example::@compute[%arg0](%arg1)
-// CHECK      : (tensor<?xf32>{%[[D0]]) -> ()
+// CHECK:   triton.dispatch @example::@compute[%[[ARG0]]](%[[ARG1]])
+// CHECK      : (tensor<?xf32>{%[[ARG0]]) -> ()
+
+// -----
+
+#layout = #hal.pipeline.layout<push_constants = 1,
+  sets = [<0, bindings = [<0, storage_buffer>]>]>
+
+triton.executable private @example {
+  triton.executable.export @compute layout(#layout)
+  builtin.module {
+    func.func @compute(%arg0: !tt.ptr<f32>) { return }
+  }
+}
+
+func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
+  triton.dispatch @example::@compute[%arg0](%arg1)
+    : (tensor<?xf32>{%arg0}) -> %arg1{%arg0}
+  return
+}
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
+// CHECK:   triton.dispatch @example::@compute[%[[ARG0]]](%[[ARG1]])
+// CHECK      : (tensor<?xf32>{%[[ARG0]]) -> %[[ARG1]]{%[[ARG0]]}
 
 // -----
 
@@ -86,15 +105,13 @@ tt.func private @triton(%arg0: !tt.ptr<f32>) {
   tt.return
 }
 
-func.func @main(%arg0: tensor<4xf32>) {
-  %c1 = arith.constant 1 : index
-  triton.call @triton[%c1](%arg0) : (tensor<4xf32>) -> ()
+func.func @main(%arg0: index, %arg1: tensor<4xf32>) {
+  triton.call @triton[%arg0](%arg1) : (tensor<4xf32>) -> ()
   return
 }
 
-// CHECK: func @main(%[[ARG:.*]]: tensor<4xf32>)
-// CHECK:   %[[C1:.*]] = arith.constant 1 : index
-// CHECK:   triton.call @triton[%[[C1]]](%[[ARG]])
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<4xf32>)
+// CHECK:   triton.call @triton[%[[ARG0]]](%[[ARG1]])
 
 // -----
 
@@ -102,17 +119,60 @@ tt.func private @triton(%arg0: !tt.ptr<f32>) {
   tt.return
 }
 
-func.func @main(%arg0: tensor<?xf32>) {
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %d0 = tensor.dim %arg0, %c0 : tensor<?xf32>
-  triton.call @triton[%c1](%arg0) : (tensor<?xf32>{%d0}) -> ()
+func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
+  triton.call @triton[%arg0](%arg1) : (tensor<?xf32>{%arg0}) -> ()
   return
 }
 
-// CHECK: func @main(%[[ARG:.*]]: tensor<?xf32>)
-// CHECK:   %[[C0:.*]] = arith.constant 0 : index
-// CHECK:   %[[C1:.*]] = arith.constant 1 : index
-// CHECK:   %[[D0:.*]] = tensor.dim %[[ARG]], %[[C0]] : tensor<?xf32>
-// CHECK:   triton.call @triton[%[[C1]]](%[[ARG]])
-// CHECK:     : (tensor<?xf32>{%[[D0]]}) -> ()
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
+// CHECK:   triton.call @triton[%[[ARG0]]](%[[ARG1]])
+// CHECK:     : (tensor<?xf32>{%[[ARG0]]}) -> ()
+
+// -----
+
+tt.func private @triton(%arg0: !tt.ptr<f32>) {
+  tt.return
+}
+
+func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
+  triton.call @triton[%arg0](%arg1) : (tensor<?xf32>{%arg0}) -> %arg1{%arg0}
+  return
+}
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
+// CHECK:   triton.call @triton[%[[ARG0]]](%[[ARG1]])
+// CHECK:     : (tensor<?xf32>{%[[ARG0]]}) -> %[[ARG1]]{%[[ARG0]]}
+
+// -----
+
+tt.func private @triton(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
+  tt.return
+}
+
+func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
+  triton.call @triton[%arg0](%arg1)
+    : (tensor<?xf32>{%arg0}) -> (%arg1{%arg0}, tensor<?xf32>{%arg0})
+  return
+}
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
+// CHECK:   triton.call @triton[%[[ARG0]]](%[[ARG1]])
+// CHECK:     : (tensor<?xf32>{%[[ARG0]]})
+// CHECK:    -> (%[[ARG1]]{%[[ARG0]]}, tensor<?xf32>{%[[ARG0]]})
+
+// -----
+
+tt.func private @triton(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
+  tt.return
+}
+
+func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
+  triton.call @triton[%arg0](%arg1)
+    : (tensor<?xf32>{%arg0}) -> (tensor<?xf32>{%arg0}, %arg1{%arg0})
+  return
+}
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
+// CHECK:   triton.call @triton[%[[ARG0]]](%[[ARG1]])
+// CHECK:     : (tensor<?xf32>{%[[ARG0]]})
+// CHECK:    -> (tensor<?xf32>{%[[ARG0]]}, %[[ARG1]]{%[[ARG0]]})

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/OutlineTritonCalls.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/OutlineTritonCalls.cpp
@@ -170,7 +170,7 @@ static void updateTritonCallForAbi(tritonflow::CallOp call,
     int64_t newArgIdx = permutaion[i];
 
     // In Triton function type scalar (constant) arguments are passed after
-    // destination buffer for results, so we have to adjust index for that.
+    // destination pointers for results, so we have to adjust index for that.
     if (newArgIdx >= args.size()) newArgIdx -= numUntiedResults;
 
     abiArgs[newArgIdx] = args[i];
@@ -178,7 +178,7 @@ static void updateTritonCallForAbi(tritonflow::CallOp call,
 
   call.getArgumentsMutable().assign(abiArgs);
 
-  // Tie results to the new operands after indices after applying permutation.
+  // Tie results to the new operands after updating arguments.
   if (auto tiedOperands = call.getTiedOperands()) {
     SmallVector<int64_t> abiTiedOperands;
 

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/outline_triton_calls.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/outline_triton_calls.mlir
@@ -2,7 +2,7 @@
 // RUN:             --openxla-nvgpu-outline-triton-calls                       \
 // RUN:   | FileCheck %s
 
-tt.func @triton(%arg0: i32, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>) {
+tt.func @triton(%arg0: i32 {tt.foo}, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>) {
   tt.return
 }
 
@@ -20,17 +20,17 @@ func.func @main(%arg0: tensor<?xf32>) -> tensor<?xf32> {
   return %0 : tensor<?xf32>
 }
 
-// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout<push_constants = 1,
-// CHECK:   sets = [<0, bindings = [
-// CHECK:                 <0, storage_buffer, ReadOnly>,
-// CHECK:                 <1, storage_buffer>
-// CHECK:               ]>
-// CHECK:          ]>
+// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
+// CHECK:   push_constants = 1
+// CHECK:   <0, storage_buffer, ReadOnly>
+// CHECK:   <1, storage_buffer>
+// CHECK-NOT: storage_buffer
 
 // CHECK: triton.executable public @triton.executable {
 // CHECK:     triton.executable.export public @triton layout(#[[LAYOUT]])
 // CHECK:     builtin.module {
-// CHECK:       tt.func @triton({{.*}}) {
+// CHECK:       tt.func @triton(%{{.*}}: !tt.ptr<f32>, %{{.*}}: !tt.ptr<f32>,
+// CHECK:                       %{{.*}}: i32 {tt.foo})
 // CHECK:         tt.return
 // CHECK:       }
 // CHECK:     }
@@ -43,3 +43,64 @@ func.func @main(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK:                                 (%[[ARG0]], %[[I32]])
 // CHECK:   return %[[RES]] : tensor<?xf32>
 // CHECK: }
+
+// -----
+// Check outlining Triton functions with tied results.
+
+tt.func @triton(%arg0: i32 {tt.foo}, %arg1: !tt.ptr<f32>) {
+  tt.return
+}
+
+func.func @main(%arg0: index, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %i32 = arith.index_cast %arg0 : index to i32
+  %0 = triton.call @triton[%arg0](%i32, %arg1)
+       : (i32, tensor<?xf32>{%arg0}) -> %arg1{%arg0}
+  return %0 : tensor<?xf32>
+}
+
+// CHECK: #hal.pipeline.layout
+// CHECK:   push_constants = 1
+// CHECK:   <0, storage_buffer>
+// CHECK-NOT: storage_buffer
+
+// CHECK: triton.executable
+// CHECK:   builtin.module
+// CHECK:     tt.func @triton(%{{.*}}: !tt.ptr<f32>, %{{.*}}: i32 {tt.foo})
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
+// CHECK:   %[[I32:.*]] = arith.index_cast
+// CHECK:   %[[RES:.*]] = triton.dispatch @triton.executable::@triton[%[[ARG0]]]
+// CHECK:                   (%[[ARG1]], %[[I32]]) {{.*}} -> %[[ARG1]]{%[[ARG0]]}
+// CHECK:   return %[[RES]] : tensor<?xf32>
+// CHECK: }
+
+// -----
+// Check outlining Triton functions with tied and regular results.
+
+tt.func @triton(%arg0: i32, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<i32>) {
+  tt.return
+}
+
+func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
+  %i32 = arith.index_cast %arg0 : index to i32
+  %0:2 = triton.call @triton[%arg0](%i32, %arg1)
+         : (i32, tensor<?xf32>{%arg0}) -> (%arg1{%arg0}, tensor<?xi32>{%arg0})
+  return
+}
+
+// CHECK: #hal.pipeline.layout
+// CHECK:   push_constants = 1
+// CHECK:   <0, storage_buffer>,
+// CHECK:   <1, storage_buffer>
+// CHECK-NOT: storage_buffer
+
+// CHECK: triton.executable
+// CHECK:   builtin.module
+// CHECK:     tt.func @triton(%{{.*}}: !tt.ptr<f32>, %{{.*}}: !tt.ptr<i32>,
+// CHECK:                     %{{.*}}: i32)
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
+// CHECK:   %[[I32:.*]] = arith.index_cast
+// CHECK:   triton.dispatch @triton.executable::@triton[%[[ARG0]]]
+// CHECK:      (%[[ARG1]], %[[I32]])
+// CHECK:   -> (%[[ARG1]]{%[[ARG0]]}, tensor<?xi32>{%[[ARG0]]}


### PR DESCRIPTION
* Update `triton.call` and `triton.dispatch` verifiers to correctly handle tied results.
* Fix pipeline layout (ABI) inference for tied layouts
* Update outlining pass to correctly handle tied results
* Forward argument attributes to outlined triton executable