### PR TITLE
[Triton] NFC: Split Triton ABI refinement into a separate pass

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.cpp
@@ -301,7 +301,7 @@ LogicalResult DispatchOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Check that Triton function is compatible with the dispatch arguments.
   if (failed(verifyTritonFunction(getOperation(), tritonFunc.getFunctionType(),
                                   getArguments(), getResults(),
-                                  exportOp.getLayout()))) {
+                                  exportOp.getLayout().value_or(nullptr)))) {
     return failure();
   }
 

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.td
@@ -119,13 +119,13 @@ def TritonFlow_ExecutableExportOp : TritonFlow_Op<"executable.export", [
     OptionalAttr<StrAttr>:$sym_visibility,
     SymbolNameAttr:$sym_name,
     FlatSymbolRefAttr:$function_ref,
-    HAL_PipelineLayoutAttr:$layout
+    OptionalAttr<HAL_PipelineLayoutAttr>:$layout
   );
 
   let assemblyFormat = [{
     custom<SymbolVisibility>($sym_visibility)
     custom<SymbolAlias>($sym_name, $function_ref)
-    `layout` `(` $layout `)`
+    (`layout` `(` $layout^ `)` )?
     attr-dict-with-keyword
   }];
 
@@ -133,7 +133,7 @@ def TritonFlow_ExecutableExportOp : TritonFlow_Op<"executable.export", [
     OpBuilder<(ins
       "llvm::StringRef":$sym_name,
       "mlir::FlatSymbolRefAttr":$function_ref,
-      "mlir::iree_compiler::IREE::HAL::PipelineLayoutAttr":$layout)>,
+      CArg<"mlir::iree_compiler::IREE::HAL::PipelineLayoutAttr", "nullptr">:$layout)>,
   ];
 }
 

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/BUILD.bazel
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/BUILD.bazel
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_gentbl_cc_library", "iree_tablegen_doc", "iree_td_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_gentbl_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -49,6 +49,7 @@ cc_library(
         "ConvertTritonToFlowDispatch.cpp",
         "OutlineTritonCalls.cpp",
         "Passes.cpp",
+        "RefineTritonAbi.cpp",
     ],
     hdrs = ["Passes.h"],
     deps = [

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/CMakeLists.txt
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     "ConvertTritonToFlowDispatch.cpp"
     "OutlineTritonCalls.cpp"
     "Passes.cpp"
+    "RefineTritonAbi.cpp"
   DEPS
     ::PassHeaders
     MLIRPass

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/OutlineTritonCalls.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/OutlineTritonCalls.cpp
@@ -11,10 +11,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
-#include <optional>
 
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Module.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -23,7 +20,6 @@
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/SymbolTable.h"
-#include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Types.h"
 #include "mlir/IR/Value.h"
 #include "mlir/IR/Visitors.h"
@@ -34,177 +30,15 @@
 #define GEN_PASS_DEF_OUTLINETRITONCALLS
 #include "openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/Passes.h.inc"
 
-namespace IREE = mlir::iree_compiler::IREE;
-
 using namespace mlir;
 
 namespace openxla::compiler::nvgpu::tritonflow {
-
-// Returns true if the type uses `pushConstants` IREE ABI.
-static bool isPushConstant(Type type) { return type.isIntOrIndex(); }
-
-// Returns the IREE HAL pipeline layout inferred from the Triton call operation.
-// TODO(ezhulenev): Add support for tied results.
-static IREE::HAL::PipelineLayoutAttr getPipelineLayout(tritonflow::CallOp call,
-                                                       triton::FuncOp callee) {
-  MLIRContext* ctx = callee->getContext();
-
-  // Scalar arguments passed as dispatch constants.
-  int64_t pushConstants =
-      llvm::count_if(callee.getArgumentTypes(), isPushConstant);
-
-  // Bindings for all tensor (pointer) arguments.
-  llvm::SmallVector<IREE::HAL::DescriptorSetBindingAttr> bindings;
-
-  for (auto arg : llvm::enumerate(call.getArguments())) {
-    // If argument is not tied to any results we assume it's read only. It's
-    // undefined behavior if Triton implementation writes to the argument.
-    int64_t index = call.getTiedOperandsIndexAndLength().first + arg.index();
-    std::optional<IREE::HAL::DescriptorFlags> flags =
-        !call.isOperandTied(index)
-            ? std::optional(IREE::HAL::DescriptorFlags::ReadOnly)
-            : std::nullopt;
-
-    if (auto tensor = arg.value().getType().dyn_cast<RankedTensorType>()) {
-      bindings.push_back(IREE::HAL::DescriptorSetBindingAttr::get(
-          ctx, /*ordinal=*/bindings.size(),
-          IREE::HAL::DescriptorType::StorageBuffer, flags));
-    }
-  }
-
-  for (auto ret : call.getResults()) {
-    // Skip tied results as they alrady passed in as arguments.
-    if (call.getTiedResultOperand(ret)) continue;
-
-    if (auto tensor = ret.getType().dyn_cast<RankedTensorType>()) {
-      bindings.push_back(IREE::HAL::DescriptorSetBindingAttr::get(
-          ctx, /*ordinal=*/bindings.size(),
-          IREE::HAL::DescriptorType::StorageBuffer, std::nullopt));
-    }
-  }
-
-  return IREE::HAL::PipelineLayoutAttr::get(
-      ctx, pushConstants,
-      IREE::HAL::DescriptorSetLayoutAttr::get(ctx, /*ordinal=*/0, bindings));
-}
-
-// Updates Triton function signature to be compatible with IREE dispatch ABI. If
-// function type was updated, returns an argument permutation that was applied.
-static std::optional<SmallVector<int64_t>> updateTritonFunctionForAbi(
-    triton::FuncOp callee) {
-  MLIRContext* ctx = callee->getContext();
-
-  // We need to compute permutation of function arguments to update callsites.
-  struct IndexedArg {
-    size_t index;
-    Type type;
-  };
-
-  SmallVector<IndexedArg> args;
-  for (auto indexed : llvm::enumerate(callee.getArgumentTypes()))
-    args.push_back({indexed.index(), indexed.value()});
-
-  // Partition arguments types, so that all scalars pushed to the end.
-  auto firstScalarArg = std::stable_partition(
-      args.begin(), args.end(),
-      [](IndexedArg indexed) { return !isPushConstant(indexed.type); });
-
-  // Function already has an ABI-compatibe signature.
-  if (firstScalarArg == args.end() ||
-      std::distance(args.begin(), firstScalarArg) == firstScalarArg->index) {
-    return std::nullopt;
-  }
-
-  // Types according to the new ABI and a permutation to get there.
-  SmallVector<Type> abiTypes;
-  SmallVector<int64_t> abiPermutation(args.size());
-
-  // Add new block arguments accoding to the ABI signature, and forward all
-  // users of original arguments to the new args.
-  Block& entryBlock = callee.front();
-
-  for (auto arg : llvm::enumerate(args)) {
-    size_t index = arg.index();
-    IndexedArg value = arg.value();
-
-    abiTypes.push_back(value.type);
-    abiPermutation[value.index] = index;
-
-    auto originalArg = entryBlock.getArgument(value.index);
-    auto abiArg = entryBlock.addArgument(value.type, originalArg.getLoc());
-    originalArg.replaceAllUsesWith(abiArg);
-  }
-
-  // Erase original types.
-  entryBlock.eraseArguments(0, args.size());
-
-  // Update function signature to the new type.
-  auto abiFunctionType = FunctionType::get(ctx, abiTypes, TypeRange());
-  callee.setFunctionType(abiFunctionType);
-
-  // Update function argument attributes to match new basic block arguments.
-  SmallVector<DictionaryAttr> argAttrs;
-  SmallVector<DictionaryAttr> abiArgAttrs(args.size());
-  callee.getAllArgAttrs(argAttrs);
-  for (unsigned i = 0; i < args.size(); ++i) {
-    abiArgAttrs[abiPermutation[i]] = argAttrs[i];
-  }
-  callee.setAllArgAttrs(abiArgAttrs);
-
-  return abiPermutation;
-}
-
-// Updates Triton call operation according to the arguments permutation computed
-// by the `updateTritonFunctionForAbi` function defined above.
-static void updateTritonCallForAbi(tritonflow::CallOp call,
-                                   SmallVector<int64_t> permutaion) {
-  SmallVector<Value> args = llvm::to_vector(call.getArguments());
-  SmallVector<Value> abiArgs(call.getArguments().size());
-
-  // Number of result tensors not tied to any of the operands.
-  size_t numUntiedResults = llvm::count_if(
-      call.getResults(),
-      [&](Value result) { return !call.getTiedResultOperand(result); });
-
-  for (unsigned i = 0; i < args.size(); ++i) {
-    int64_t newArgIdx = permutaion[i];
-
-    // In Triton function type scalar (constant) arguments are passed after
-    // destination pointers for results, so we have to adjust index for that.
-    if (newArgIdx >= args.size()) newArgIdx -= numUntiedResults;
-
-    abiArgs[newArgIdx] = args[i];
-  }
-
-  call.getArgumentsMutable().assign(abiArgs);
-
-  // Tie results to the new operands after updating arguments.
-  if (auto tiedOperands = call.getTiedOperands()) {
-    SmallVector<int64_t> abiTiedOperands;
-
-    for (auto attr : tiedOperands->getValue()) {
-      auto idx = attr.cast<IntegerAttr>().getInt();
-      abiTiedOperands.push_back(idx < 0 ? idx : permutaion[idx]);
-    }
-
-    call.setTiedOperandsAttr(
-        OpBuilder(call).getIndexArrayAttr(abiTiedOperands));
-  }
-}
 
 static LogicalResult outlineTritonFlowCallOp(tritonflow::CallOp call,
                                              SymbolTable& symTable) {
   // Get the Triton function callee.
   auto callee = symTable.lookup<triton::FuncOp>(call.getCallee());
   ImplicitLocOpBuilder b(callee->getLoc(), call->getParentOfType<ModuleOp>());
-
-  // Update function and a call operation to be ABI compatible.
-  if (auto permutation = updateTritonFunctionForAbi(callee)) {
-    updateTritonCallForAbi(call, *permutation);
-  }
-
-  // Get the IREE pipeline layout (aka ABI) from the callee.
-  IREE::HAL::PipelineLayoutAttr layout = getPipelineLayout(call, callee);
 
   // Create executable right after the original Triton function.
   b.setInsertionPointAfter(callee);
@@ -221,8 +55,8 @@ static LogicalResult outlineTritonFlowCallOp(tritonflow::CallOp call,
 
   // Export Triton function from the executable.
   b.setInsertionPointToStart(&executableOp.getBlock());
-  auto exportExecutableOp = b.create<ExecutableExportOp>(
-      callee.getSymName(), call.getCalleeAttr(), layout);
+  auto exportExecutableOp =
+      b.create<ExecutableExportOp>(callee.getSymName(), call.getCalleeAttr());
 
   // Replace call operation with a Triton executable dispatch.
   b.setLoc(call.getLoc());

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/Passes.h
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/Passes.h
@@ -20,6 +20,8 @@ namespace openxla::compiler::nvgpu::tritonflow {
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createOutlineTritonCallsPass();
 
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createRefineTritonAbi();
+
 //===----------------------------------------------------------------------===//
 // Conversions from TritonFlow dialect
 //===----------------------------------------------------------------------===//

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/Passes.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/Passes.td
@@ -23,6 +23,19 @@ def OutlineTritonCalls :
 
   let dependentDialects = [
     "openxla::compiler::nvgpu::tritonflow::TritonFlowDialect",
+  ];
+}
+
+def RefineTritonAbi :
+    Pass<"openxla-nvgpu-refine-triton-abi", "mlir::ModuleOp"> {
+  let summary = "Refines Triton executables ABI to be compatible with IREE";
+
+  let constructor = [{
+    openxla::compiler::nvgpu::tritonflow::createRefineTritonAbi()
+  }];
+
+  let dependentDialects = [
+    "openxla::compiler::nvgpu::tritonflow::TritonFlowDialect",
     "mlir::iree_compiler::IREE::HAL::HALDialect",
   ];
 }

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/RefineTritonAbi.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/RefineTritonAbi.cpp
@@ -1,0 +1,237 @@
+// Copyright 2023 The OpenXLA Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <optional>
+
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Module.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/TypeRange.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Support/LogicalResult.h"
+#include "openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.h"
+#include "openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/PassDetail.h"
+#include "openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/Passes.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#define GEN_PASS_DEF_REFINETRITONABI
+#include "openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/Passes.h.inc"
+
+namespace openxla::compiler::nvgpu::tritonflow {
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+
+// Returns true if the type uses `pushConstants` IREE ABI.
+static bool isPushConstant(Type type) { return type.isIntOrIndex(); }
+
+// Returns the IREE HAL pipeline layout inferred from the Triton dispatch.
+static IREE::HAL::PipelineLayoutAttr getPipelineLayout(DispatchOp dispatch,
+                                                       triton::FuncOp callee) {
+  MLIRContext* ctx = dispatch->getContext();
+
+  // Scalar arguments passed as dispatch constants.
+  int64_t pushConstants =
+      llvm::count_if(callee.getArgumentTypes(), isPushConstant);
+
+  // Bindings for all tensor (pointer) arguments.
+  SmallVector<IREE::HAL::DescriptorSetBindingAttr> bindings;
+
+  for (auto arg : llvm::enumerate(dispatch.getArguments())) {
+    // If argument is not tied to any results we assume it's read only. It's
+    // undefined behavior if Triton implementation writes to the argument.
+    auto index = dispatch.getTiedOperandsIndexAndLength().first + arg.index();
+    std::optional<IREE::HAL::DescriptorFlags> flags =
+        !dispatch.isOperandTied(index)
+            ? std::optional(IREE::HAL::DescriptorFlags::ReadOnly)
+            : std::nullopt;
+
+    if (auto tensor = arg.value().getType().dyn_cast<RankedTensorType>()) {
+      bindings.push_back(IREE::HAL::DescriptorSetBindingAttr::get(
+          ctx, /*ordinal=*/bindings.size(),
+          IREE::HAL::DescriptorType::StorageBuffer, flags));
+    }
+  }
+
+  for (auto ret : dispatch.getResults()) {
+    // Skip tied results as they alrady passed in as arguments.
+    if (dispatch.getTiedResultOperand(ret)) continue;
+
+    if (auto tensor = ret.getType().dyn_cast<RankedTensorType>()) {
+      bindings.push_back(IREE::HAL::DescriptorSetBindingAttr::get(
+          ctx, /*ordinal=*/bindings.size(),
+          IREE::HAL::DescriptorType::StorageBuffer, std::nullopt));
+    }
+  }
+
+  return IREE::HAL::PipelineLayoutAttr::get(
+      ctx, pushConstants,
+      IREE::HAL::DescriptorSetLayoutAttr::get(ctx, /*ordinal=*/0, bindings));
+}
+
+// Updates Triton function signature to be compatible with IREE dispatch ABI. If
+// function type was updated, returns an argument permutation that was applied.
+static std::optional<SmallVector<int64_t>> updateTritonFunctionForAbi(
+    triton::FuncOp callee) {
+  MLIRContext* ctx = callee->getContext();
+
+  // We need to compute permutation of function arguments to update callsites.
+  struct IndexedArg {
+    size_t index;
+    Type type;
+  };
+
+  SmallVector<IndexedArg> args;
+  for (auto indexed : llvm::enumerate(callee.getArgumentTypes()))
+    args.push_back({indexed.index(), indexed.value()});
+
+  // Partition arguments types, so that all constants pushed to the end.
+  auto firstScalarArg = std::stable_partition(
+      args.begin(), args.end(),
+      [](IndexedArg indexed) { return !isPushConstant(indexed.type); });
+
+  // Function already has an ABI-compatibe signature.
+  if (firstScalarArg == args.end() ||
+      std::distance(args.begin(), firstScalarArg) == firstScalarArg->index) {
+    return std::nullopt;
+  }
+
+  // Types according to the new ABI and a permutation to get there.
+  SmallVector<Type> abiTypes;
+  SmallVector<int64_t> abiPermutation(args.size());
+
+  // Add new block arguments accoding to the ABI signature, and forward all
+  // users of original arguments to the new args.
+  Block& entryBlock = callee.front();
+
+  for (auto arg : llvm::enumerate(args)) {
+    size_t index = arg.index();
+    IndexedArg value = arg.value();
+
+    abiTypes.push_back(value.type);
+    abiPermutation[value.index] = index;
+
+    auto originalArg = entryBlock.getArgument(value.index);
+    auto abiArg = entryBlock.addArgument(value.type, originalArg.getLoc());
+    originalArg.replaceAllUsesWith(abiArg);
+  }
+
+  // Erase original types.
+  entryBlock.eraseArguments(0, args.size());
+
+  // Update function signature to the new type.
+  auto abiFunctionType = FunctionType::get(ctx, abiTypes, TypeRange());
+  callee.setFunctionType(abiFunctionType);
+
+  // Update function argument attributes to match new basic block arguments.
+  SmallVector<DictionaryAttr> argAttrs;
+  SmallVector<DictionaryAttr> abiArgAttrs(args.size());
+  callee.getAllArgAttrs(argAttrs);
+  for (unsigned i = 0; i < args.size(); ++i) {
+    abiArgAttrs[abiPermutation[i]] = argAttrs[i];
+  }
+  callee.setAllArgAttrs(abiArgAttrs);
+
+  return abiPermutation;
+}
+
+// Updates Triton dispatch operation according to the arguments permutation
+// computed by the `updateTritonFunctionForAbi` function defined above.
+static void updateTritonDispatchForAbi(DispatchOp dispatch,
+                                       SmallVector<int64_t> permutaion) {
+  SmallVector<Value> args = llvm::to_vector(dispatch.getArguments());
+  SmallVector<Value> abiArgs(dispatch.getArguments().size());
+
+  // Number of result tensors not tied to any of the operands.
+  size_t numUntiedResults = llvm::count_if(
+      dispatch.getResults(),
+      [&](Value result) { return !dispatch.getTiedResultOperand(result); });
+
+  for (unsigned i = 0; i < args.size(); ++i) {
+    int64_t newArgIdx = permutaion[i];
+
+    // In Triton function type scalar (constant) arguments are passed after
+    // destination pointers for results, so we have to adjust index for that.
+    if (newArgIdx >= args.size()) newArgIdx -= numUntiedResults;
+
+    abiArgs[newArgIdx] = args[i];
+  }
+
+  dispatch.getArgumentsMutable().assign(abiArgs);
+
+  // Tie results to the new operands after updating arguments.
+  if (auto tiedOperands = dispatch.getTiedOperands()) {
+    SmallVector<int64_t> abiTiedOperands;
+
+    for (auto attr : tiedOperands->getValue()) {
+      auto idx = attr.cast<IntegerAttr>().getInt();
+      abiTiedOperands.push_back(idx < 0 ? idx : permutaion[idx]);
+    }
+
+    dispatch.setTiedOperandsAttr(
+        OpBuilder(dispatch).getIndexArrayAttr(abiTiedOperands));
+  }
+}
+
+static void refineTritonAbi(DispatchOp dispatch, SymbolTable& symTable) {
+  // Find the Triton export declaration corresponding to dispatch operation.
+  auto exportOp = symTable.lookupNearestSymbolFrom<ExecutableExportOp>(
+      dispatch, dispatch.getEntryPoint());
+  assert(!exportOp.getLayout().has_value() && "layout already defined");
+
+  // Find the exported function in the inner module.
+  auto innerModule = exportOp.getParentOp<ExecutableOp>().getInnerModule();
+  auto callee = symTable.lookupNearestSymbolFrom<triton::FuncOp>(
+      innerModule, exportOp.getFunctionRefAttr());
+  assert(callee && "callee must be a Triton function");
+
+  // Update Triton function and a dispatch operation to be ABI compatible.
+  if (auto permutation = updateTritonFunctionForAbi(callee)) {
+    updateTritonDispatchForAbi(dispatch, *permutation);
+  }
+
+  // Set the IREE pipeline layout (aka ABI) inferred from the Triton signature.
+  IREE::HAL::PipelineLayoutAttr layout = getPipelineLayout(dispatch, callee);
+  exportOp.setLayoutAttr(layout);
+}
+
+// TODO(ezhulenev): Currently we assume that there is a 1-to-1 mapping between
+// dispatch and executable, however it might not always be the case, and
+// different dispatches might use different combination of tied results, and
+// each callsite might have a unique ABI.
+class RefineTritonAbi : public ::impl::RefineTritonAbiBase<RefineTritonAbi> {
+ public:
+  void runOnOperation() override {
+    SmallVector<DispatchOp> dispatches;
+    getOperation()->walk([&](DispatchOp op) { dispatches.push_back(op); });
+
+    // Don't build potentially expensive symbols table if we have no work to do.
+    if (dispatches.empty()) return;
+
+    SymbolTable symTable(getOperation());
+    for (auto dispatch : dispatches) {
+      refineTritonAbi(dispatch, symTable);
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<ModuleOp>> createRefineTritonAbi() {
+  return std::make_unique<RefineTritonAbi>();
+}
+
+}  // namespace openxla::compiler::nvgpu::tritonflow

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/BUILD.bazel
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/BUILD.bazel
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "outline_triton_calls.mlir",
+            "refine_triton_abi.mlir",
             "triton_to_flow_dispatch.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "outline_triton_calls.mlir"
+    "refine_triton_abi.mlir"
     "triton_to_flow_dispatch.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/outline_triton_calls.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/outline_triton_calls.mlir
@@ -6,101 +6,26 @@ tt.func @triton(%arg0: i32 {tt.foo}, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>) {
   tt.return
 }
 
-func.func @main(%arg0: tensor<?xf32>) -> tensor<?xf32> {
-  %c0 = arith.constant 0 : index
-  %d0 = tensor.dim %arg0, %c0 : tensor<?xf32>
-  %g0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%d0]
-
-  // Currently ABI only supports i32 scalars.
-  %d0_i32 = arith.index_cast %d0 : index to i32
-
-  %0 = triton.call @triton[%g0](%d0_i32, %arg0)
-    : (i32, tensor<?xf32>{%d0}) -> tensor<?xf32>{%d0}
+func.func @main(%idx: index, %i32: i32, %arg: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = triton.call @triton[%idx](%i32, %arg)
+       : (i32, tensor<?xf32>{%idx}) -> tensor<?xf32>{%idx}
 
   return %0 : tensor<?xf32>
 }
 
-// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
-// CHECK:   push_constants = 1
-// CHECK:   <0, storage_buffer, ReadOnly>
-// CHECK:   <1, storage_buffer>
-// CHECK-NOT: storage_buffer
-
 // CHECK: triton.executable public @triton.executable {
-// CHECK:     triton.executable.export public @triton layout(#[[LAYOUT]])
+// CHECK:     triton.executable.export public @triton
 // CHECK:     builtin.module {
-// CHECK:       tt.func @triton(%{{.*}}: !tt.ptr<f32>, %{{.*}}: !tt.ptr<f32>,
-// CHECK:                       %{{.*}}: i32 {tt.foo})
+// CHECK:       tt.func @triton(%{{.*}}: i32 {tt.foo}, %{{.*}}: !tt.ptr<f32>,
+// CHECK:                       %{{.*}}: !tt.ptr<f32>)
 // CHECK:         tt.return
 // CHECK:       }
 // CHECK:     }
 // CHECK:   }
 
-// CHECK: func @main(%[[ARG0:.*]]: tensor<?xf32>) -> tensor<?xf32> {
-// CHECK:   %[[G0:.*]] = affine.apply
-// CHECK:   %[[I32:.*]] = arith.index_cast
-// CHECK:   %[[RES:.*]] = triton.dispatch @triton.executable::@triton[%[[G0]]]
-// CHECK:                                 (%[[ARG0]], %[[I32]])
-// CHECK:   return %[[RES]] : tensor<?xf32>
-// CHECK: }
-
-// -----
-// Check outlining Triton functions with tied results.
-
-tt.func @triton(%arg0: i32 {tt.foo}, %arg1: !tt.ptr<f32>) {
-  tt.return
-}
-
-func.func @main(%arg0: index, %arg1: tensor<?xf32>) -> tensor<?xf32> {
-  %i32 = arith.index_cast %arg0 : index to i32
-  %0 = triton.call @triton[%arg0](%i32, %arg1)
-       : (i32, tensor<?xf32>{%arg0}) -> %arg1{%arg0}
-  return %0 : tensor<?xf32>
-}
-
-// CHECK: #hal.pipeline.layout
-// CHECK:   push_constants = 1
-// CHECK:   <0, storage_buffer>
-// CHECK-NOT: storage_buffer
-
-// CHECK: triton.executable
-// CHECK:   builtin.module
-// CHECK:     tt.func @triton(%{{.*}}: !tt.ptr<f32>, %{{.*}}: i32 {tt.foo})
-
-// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
-// CHECK:   %[[I32:.*]] = arith.index_cast
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: i32,
+// CHECK:            %[[ARG2:.*]]: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK:   %[[RES:.*]] = triton.dispatch @triton.executable::@triton[%[[ARG0]]]
-// CHECK:                   (%[[ARG1]], %[[I32]]) {{.*}} -> %[[ARG1]]{%[[ARG0]]}
+// CHECK:                 (%[[ARG1]], %[[ARG2]]) {{.*}} tensor<?xf32>{%[[ARG0]]}
 // CHECK:   return %[[RES]] : tensor<?xf32>
 // CHECK: }
-
-// -----
-// Check outlining Triton functions with tied and regular results.
-
-tt.func @triton(%arg0: i32, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<i32>) {
-  tt.return
-}
-
-func.func @main(%arg0: index, %arg1: tensor<?xf32>) {
-  %i32 = arith.index_cast %arg0 : index to i32
-  %0:2 = triton.call @triton[%arg0](%i32, %arg1)
-         : (i32, tensor<?xf32>{%arg0}) -> (%arg1{%arg0}, tensor<?xi32>{%arg0})
-  return
-}
-
-// CHECK: #hal.pipeline.layout
-// CHECK:   push_constants = 1
-// CHECK:   <0, storage_buffer>,
-// CHECK:   <1, storage_buffer>
-// CHECK-NOT: storage_buffer
-
-// CHECK: triton.executable
-// CHECK:   builtin.module
-// CHECK:     tt.func @triton(%{{.*}}: !tt.ptr<f32>, %{{.*}}: !tt.ptr<i32>,
-// CHECK:                     %{{.*}}: i32)
-
-// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<?xf32>)
-// CHECK:   %[[I32:.*]] = arith.index_cast
-// CHECK:   triton.dispatch @triton.executable::@triton[%[[ARG0]]]
-// CHECK:      (%[[ARG1]], %[[I32]])
-// CHECK:   -> (%[[ARG1]]{%[[ARG0]]}, tensor<?xi32>{%[[ARG0]]}

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/refine_triton_abi.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/refine_triton_abi.mlir
@@ -1,0 +1,167 @@
+// RUN: iree-opt %s --iree-plugin=openxla-triton --split-input-file            \
+// RUN:             --openxla-nvgpu-refine-triton-abi                          \
+// RUN:   | FileCheck %s
+
+triton.executable private @triton {
+  triton.executable.export @foo
+  builtin.module {
+    tt.func @foo(%idx: !tt.ptr<f32>) { tt.return }
+  }
+}
+
+func.func @main(%idx: index, %arg1: tensor<f32>) {
+  triton.dispatch @triton::@foo[%idx](%arg1) : (tensor<f32>) -> ()
+  return
+}
+
+// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
+// CHECK:   push_constants = 0
+// CHECK:   <0, storage_buffer, ReadOnly>
+// CHECK-NOT: storage_buffer
+
+// CHECK: triton.executable
+// CHECK:   triton.executable.export public @foo layout(#[[LAYOUT]])
+// CHECK:   tt.func @foo({{.*}}: !tt.ptr<f32>)
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: tensor<f32>)
+// CHECK:   triton.dispatch @triton::@foo[%[[ARG0]]](%[[ARG1]])
+
+// -----
+
+triton.executable private @triton {
+  triton.executable.export @foo
+  builtin.module {
+    tt.func @foo(%idx: !tt.ptr<f32>) { tt.return }
+  }
+}
+
+func.func @main(%idx: index) {
+  triton.dispatch @triton::@foo[%idx]() : () -> (tensor<f32>)
+  return
+}
+
+// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
+// CHECK:   push_constants = 0
+// CHECK:   <0, storage_buffer>
+// CHECK-NOT: storage_buffer
+
+// CHECK: triton.executable
+// CHECK:   triton.executable.export public @foo layout(#[[LAYOUT]])
+// CHECK:   tt.func @foo({{.*}}: !tt.ptr<f32>)
+
+// CHECK: func @main(%[[ARG0:.*]]: index)
+// CHECK:   triton.dispatch @triton::@foo[%[[ARG0]]]()
+
+// -----
+
+triton.executable private @triton {
+  triton.executable.export @foo
+  builtin.module {
+    tt.func @foo(%arg0: i32 {tt.foo}, %arg1: !tt.ptr<f32>) { tt.return }
+  }
+}
+
+func.func @main(%idx: index, %arg1: i32) {
+  triton.dispatch @triton::@foo[%idx](%arg1) : (i32) -> (tensor<f32>)
+  return
+}
+
+// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
+// CHECK:   push_constants = 1
+// CHECK:   <0, storage_buffer>
+// CHECK-NOT: storage_buffer
+
+// CHECK: triton.executable
+// CHECK:   triton.executable.export public @foo layout(#[[LAYOUT]])
+// CHECK:   tt.func @foo({{.*}}: !tt.ptr<f32>, {{.*}}: i32 {tt.foo})
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: i32)
+// CHECK:   triton.dispatch @triton::@foo[%[[ARG0]]](%[[ARG1]])
+
+// -----
+
+triton.executable private @triton {
+  triton.executable.export @foo
+  builtin.module {
+    tt.func @foo(%arg0: i32, %arg1: !tt.ptr<f32>) { tt.return }
+  }
+}
+
+func.func @main(%idx: index, %i32: i32, %arg: tensor<f32>) {
+  triton.dispatch @triton::@foo[%idx](%i32, %arg) : (i32, tensor<f32>) -> ()
+  return
+}
+
+// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
+// CHECK:   push_constants = 1
+// CHECK:   <0, storage_buffer, ReadOnly>
+// CHECK-NOT: storage_buffer
+
+// CHECK: triton.executable
+// CHECK:   triton.executable.export public @foo layout(#[[LAYOUT]])
+// CHECK:   tt.func @foo({{.*}}: !tt.ptr<f32>, {{.*}}: i32)
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: i32,
+// CHECK:            %[[ARG2:.*]]: tensor<f32>)
+// CHECK:   triton.dispatch @triton::@foo[%[[ARG0]]](%[[ARG2]], %[[ARG1]])
+
+// -----
+
+triton.executable private @triton {
+  triton.executable.export @foo
+  builtin.module {
+    tt.func @foo(%arg0: i32, %arg1: !tt.ptr<f32>) { tt.return }
+  }
+}
+
+func.func @main(%idx: index, %i32: i32, %t: tensor<f32>) {
+  triton.dispatch @triton::@foo[%idx](%i32, %t) : (i32, tensor<f32>) -> %t
+  return
+}
+
+// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
+// CHECK:   push_constants = 1
+// CHECK:   <0, storage_buffer>
+// CHECK-NOT: storage_buffer
+
+// CHECK: triton.executable
+// CHECK:   triton.executable.export public @foo layout(#[[LAYOUT]])
+// CHECK:   tt.func @foo({{.*}}: !tt.ptr<f32>, {{.*}}: i32)
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: i32,
+// CHECK:            %[[ARG2:.*]]: tensor<f32>)
+// CHECK:   triton.dispatch @triton::@foo[%[[ARG0]]](%[[ARG2]], %[[ARG1]])
+// CHECK:   : (tensor<f32>, i32) -> %[[ARG2]]
+
+// -----
+
+triton.executable private @triton {
+  triton.executable.export @foo
+  builtin.module {
+    tt.func @foo(%arg0: i32, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<i32>) {
+      tt.return
+    }
+  }
+}
+
+func.func @main(%idx: index, %i32: i32, %t: tensor<f32>) {
+  triton.dispatch @triton::@foo[%idx](%i32, %t)
+    : (i32, tensor<f32>) -> (%t, tensor<i32>)
+  return
+}
+
+// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
+// CHECK:   push_constants = 1
+// CHECK:   <0, storage_buffer>,
+// CHECK:   <1, storage_buffer>
+// CHECK-NOT: storage_buffer
+
+// CHECK: triton.executable
+// CHECK:   triton.executable.export public @foo layout(#[[LAYOUT]])
+// CHECK:   tt.func @foo({{.*}}: !tt.ptr<f32>, {{.*}}: !tt.ptr<i32>,
+// CHECK:                {{.*}}: i32)
+
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: i32,
+// CHECK:            %[[ARG2:.*]]: tensor<f32>)
+// CHECK:   triton.dispatch @triton::@foo[%[[ARG0]]](%[[ARG2]], %[[ARG1]])
+// CHECK:   : (tensor<f32>, i32) -> (%[[ARG2]], tensor<i32>)


### PR DESCRIPTION
Diff: https://github.com/ezhulenev/openxla-nvgpu/compare/triton-5...ezhulenev:openxla-nvgpu:triton-6

IREE ABI will require non-trivial type conversion for passing scalar types, so it's easier to keep trivial outlining separately.