### PR TITLE
[Triton] Use outlining + ABI inference in Triton pipeline

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Conversion/ConvertTritonToFlowDispatch.h
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Conversion/ConvertTritonToFlowDispatch.h
@@ -14,6 +14,8 @@
 
 namespace openxla::compiler::nvgpu::tritonflow {
 
+// TODO(ezhulenev): TritonOptions should be added to the Triton plugin
+// registration (see PluginRegistration.cpp).
 struct TritonOptions {
   // TODO(ezhulenev): This is a very old compute capability version that happens
   // to work on P100 GPUs attached to ezhulenev@ desktop. We have to target 7.0+
@@ -42,7 +44,7 @@ void populateTritonToFlowDispatchPatterns(mlir::TypeConverter &typeConverter,
                                           mlir::RewritePatternSet &patterns);
 
 // Build a compilation pipeline that lowers from Triton IR to LLVM. This is an
-// implentation details of the Triton to OpenXLA Triton runtime lowering and
+// implementation details of the Triton to OpenXLA Triton runtime lowering and
 // exposed only for testing it in isolation.
 void buildTritonCompilationPipeline(mlir::OpPassManager &pm,
                                     const TritonOptions &opts);

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.td
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.td
@@ -135,6 +135,10 @@ def TritonFlow_ExecutableExportOp : TritonFlow_Op<"executable.export", [
       "mlir::FlatSymbolRefAttr":$function_ref,
       CArg<"mlir::iree_compiler::IREE::HAL::PipelineLayoutAttr", "nullptr">:$layout)>,
   ];
+
+  let extraClassDeclaration = [{
+    ExecutableOp getExecutable();
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/ConvertTritonToFlowDispatch.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/ConvertTritonToFlowDispatch.cpp
@@ -9,6 +9,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "openxla/compiler/nvgpu/Dialect/TritonFlow/IR/TritonFlowOps.h"
 #include "openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/PassDetail.h"
 #include "openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/Passes.h"
 
@@ -32,9 +33,9 @@ class ConvertTritonToFlowDispatch
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type type) { return type; });
 
-    // Ensure all TritonFlow operations go away.
+    // Ensure all TritonFlow dispatches go away.
     ConversionTarget conversionTarget(*context);
-    conversionTarget.addIllegalDialect<TritonFlowDialect>();
+    conversionTarget.addIllegalOp<DispatchOp>();
     conversionTarget.addLegalDialect<IREE::HAL::HALDialect>();
     conversionTarget.addLegalDialect<IREE::Flow::FlowDialect>();
 

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/RefineTritonAbi.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/RefineTritonAbi.cpp
@@ -195,9 +195,8 @@ static void refineTritonAbi(DispatchOp dispatch, SymbolTable& symTable) {
   assert(!exportOp.getLayout().has_value() && "layout already defined");
 
   // Find the exported function in the inner module.
-  auto innerModule = exportOp.getParentOp<ExecutableOp>().getInnerModule();
   auto callee = symTable.lookupNearestSymbolFrom<triton::FuncOp>(
-      innerModule, exportOp.getFunctionRefAttr());
+      exportOp.getExecutable().getInnerModule(), exportOp.getFunctionRefAttr());
   assert(callee && "callee must be a Triton function");
 
   // Update Triton function and a dispatch operation to be ABI compatible.

--- a/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/triton_to_flow_dispatch.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Dialect/TritonFlow/Transforms/test/triton_to_flow_dispatch.mlir
@@ -2,46 +2,43 @@
 // RUN:             --openxla-nvgpu-convert-triton-to-flow-dispatch            \
 // RUN:   | FileCheck %s
 
-tt.func @triton(%arg0: i32, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>) {
-  tt.return
+#layout = #hal.pipeline.layout<push_constants = 1,
+  sets = [<0, bindings = [<0, storage_buffer, ReadOnly>,
+                          <1, storage_buffer>]>]>
+
+triton.executable public @triton {
+  triton.executable.export public @compute layout(#layout)
+  builtin.module {
+    tt.func @compute(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32) {
+      tt.return
+    }
+  }
 }
 
-func.func @main(%arg0: tensor<?xf32>) -> tensor<?xf32> {
-  %c0 = arith.constant 0 : index
-  %d0 = tensor.dim %arg0, %c0 : tensor<?xf32>
-  %g0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%d0]
-
-  // Currently ABI only supports i32 scalars.
-  %d0_i32 = arith.index_cast %d0 : index to i32
-
-  %0 = triton.call @triton[%g0](%d0_i32, %arg0)
-    : (i32, tensor<?xf32>{%d0}) -> tensor<?xf32>{%d0}
-
+func.func @main(%idx: index, %i32: i32, %arg: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = triton.dispatch @triton::@compute[%idx](%arg, %i32)
+       : (tensor<?xf32>{%idx}, i32) -> tensor<?xf32>{%idx}
   return %0 : tensor<?xf32>
 }
 
-// CHECK: #pipeline_layout = #hal.pipeline.layout<push_constants = 1,
-// CHECK:   sets = [<0, bindings = [
-// CHECK:                 <0, storage_buffer, ReadOnly>,
-// CHECK:                 <1, storage_buffer, ReadOnly>,
-// CHECK:                 <2, storage_buffer>
-// CHECK:               ]>
-// CHECK:          ]>
+// CHECK: #[[LAYOUT:.*]] = #hal.pipeline.layout
+// CHECK:   push_constants = 1,
+// CHECK:   <0, storage_buffer, ReadOnly>,
+// CHECK:   <1, storage_buffer>
+// CHECK-NOT: storage_buffer
 
-// CHECK: hal.executable.source private @triton.executable
+// CHECK: hal.executable.source private @triton
 // CHECK:   objects = #hal.executable.objects<{
 // CHECK:     #executable_target_cuda_nvptx_fb = [
 // CHECK:       #hal.executable.object<{path = "{{.*}}.ptx"}>
 // CHECK:     ]
 // CHECK:   }>
 
-// CHECK: hal.executable.export public @triton ordinal(0)
-// CHECK:   layout(#pipeline_layout)
+// CHECK: hal.executable.export public @compute ordinal(0)
+// CHECK:   layout(#[[LAYOUT]])
 // CHECK:   workgroup_size = [64 : index, 1 : index, 1 : index]
 
-// CHECK: func @main(%[[ARG0:.*]]: tensor<?xf32>)
-// CHECK:   %[[DIM:.*]] = tensor.dim
-// CHECK:   %[[GRID:.*]] = affine.apply
-// CHECK:   flow.dispatch @triton.executable::@triton[%[[GRID]]]
-// CHECK:     : (i32, tensor<?xf32>{%[[DIM]]})
-// CHECK:     -> tensor<?xf32>{%[[DIM]]}
+// CHECK: func @main(%[[ARG0:.*]]: index, %[[ARG1:.*]]: i32,
+// CHECK:            %[[ARG2:.*]]: tensor<?xf32>)
+// CHECK:   flow.dispatch @triton::@compute[%[[ARG0]]](%[[ARG2]], %[[ARG1]])
+// CHECK:     : (tensor<?xf32>{%[[ARG0]]}, i32) -> tensor<?xf32>{%[[ARG0]]}

--- a/compiler/src/openxla/compiler/nvgpu/PluginRegistration.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/PluginRegistration.cpp
@@ -64,6 +64,8 @@ struct TritonSession : public PluginSession<TritonSession, TritonOptions> {
   }
 
   void extendPreprocessingPassPipeline(OpPassManager &pm) override {
+    pm.addPass(createOutlineTritonCallsPass());
+    pm.addPass(createRefineTritonAbi());
     pm.addPass(createConvertTritonToFlowDispatchPass());
   }
 };

--- a/runtime/src/openxla/runtime/nvgpu/triton/test/triton_add_kernel.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/triton/test/triton_add_kernel.mlir
@@ -4,14 +4,14 @@
 // RUN:                   --input=128xf32=2 --input=128xf32=6                  \
 // RUN: | FileCheck %s
 
-tt.func @add_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: i32) {
+tt.func @add_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: !tt.ptr<f32>) {
   %c64_i32 = arith.constant 64 : i32
   %0 = tt.get_program_id {axis = 0 : i32} : i32
   %1 = arith.muli %0, %c64_i32 : i32
   %2 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
   %3 = tt.splat %1 : (i32) -> tensor<64xi32>
   %4 = arith.addi %3, %2 : tensor<64xi32>
-  %5 = tt.splat %arg3 : (i32) -> tensor<64xi32>
+  %5 = tt.splat %arg2 : (i32) -> tensor<64xi32>
   %6 = arith.cmpi slt, %4, %5 : tensor<64xi32>
   %7 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<64x!tt.ptr<f32>>
   %8 = tt.addptr %7, %4 : tensor<64x!tt.ptr<f32>>, tensor<64xi32>
@@ -20,7 +20,7 @@ tt.func @add_kernel(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32
   %11 = tt.addptr %10, %4 : tensor<64x!tt.ptr<f32>>, tensor<64xi32>
   %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64xf32>
   %13 = arith.addf %9, %12 : tensor<64xf32>
-  %14 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<64x!tt.ptr<f32>>
+  %14 = tt.splat %arg3 : (!tt.ptr<f32>) -> tensor<64x!tt.ptr<f32>>
   %15 = tt.addptr %14, %4 : tensor<64x!tt.ptr<f32>>, tensor<64xi32>
   tt.store %15, %13, %6 : tensor<64xf32>
   tt.return
@@ -35,7 +35,6 @@ func.func @main(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
   %d0_i32 = arith.index_cast %d0 : index to i32
 
   %0 = triton.call @add_kernel[%g0](%arg0, %arg1, %d0_i32)
-    { skip_triton_verifier } // TODO(ezhulemev): Remove this attribute!
     : (tensor<?xf32>{%d0}, tensor<?xf32>{%d0}, i32) -> tensor<?xf32>{%d0}
 
   return %0 : tensor<?xf32>


### PR DESCRIPTION
Switch TritonFlow to Triton conversion to `triton.executable` op, and use automatic `tt.func` outlining and ABI conversion.