### PR TITLE
Fix runtime tests after dependency sync

### DIFF
--- a/runtime/src/openxla/runtime/nvgpu/cudnn/benchmark/conv2d_add_bias_cudnn.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/benchmark/conv2d_add_bias_cudnn.mlir
@@ -1,5 +1,6 @@
-// RUN: iree-compile --compile-to=vm --iree-plugin=openxla-cudnn               \
-// RUN:              --iree-input-type=mhlo --iree-hal-target-backends=cuda %s \
+// RUN: iree-compile %s --iree-plugin=openxla-cudnn                            \
+// RUN:     --iree-input-type=stablehlo --compile-to=vm                        \
+// RUN:     --iree-hal-target-backends=cuda                                    \
 // RUN: | FileCheck %s
 
 util.global @handle : !cudnn.handle

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/benchmark/conv2d_add_bias_mhlo.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/benchmark/conv2d_add_bias_mhlo.mlir
@@ -1,5 +1,6 @@
-// RUN: iree-compile --compile-to=vm --iree-plugin=openxla-cudnn               \
-// RUN:              --iree-input-type=mhlo --iree-hal-target-backends=cuda %s \
+// RUN: iree-compile %s --iree-plugin=openxla-cudnn                            \
+// RUN:     --iree-input-type=stablehlo --compile-to=vm                        \
+// RUN:     --iree-hal-target-backends=cuda                                    \
 // RUN: | FileCheck %s
 
 //===-----------------------------------------------------------------------===/

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=mhlo        \
+// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=stablehlo   \
 // RUN:              --iree-hal-target-backends=cuda %s                        \
 // RUN: | iree-run-module --module=- --device=cuda --function=main             \
 // RUN: | FileCheck %s

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_1x1_add_bias.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_1x1_add_bias.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=mhlo        \
+// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=stablehlo   \
 // RUN:              --iree-hal-target-backends=cuda %s                        \
 // RUN: | iree-run-module --module=- --device=cuda --function=run.conv2d_1x1   \
 // RUN: | FileCheck %s

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_3x3_add_bias.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_3x3_add_bias.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=mhlo        \
+// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=stablehlo   \
 // RUN:              --iree-hal-target-backends=cuda %s                        \
 // RUN: | iree-run-module --module=- --device=cuda --function=run.conv2d_3x3   \
 // RUN: | FileCheck %s

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_add_bias.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_add_bias.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=mhlo        \
+// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=stablehlo   \
 // RUN:              --iree-hal-target-backends=cuda %s > %t
 
 // RUN: iree-run-module --module=%t --device=cuda --function=run.conv2d_1x1    \

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_batch_norm.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_batch_norm.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=mhlo        \
+// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=stablehlo   \
 // RUN:              --iree-hal-target-backends=cuda %s                        \
 // RUN: | iree-run-module --module=- --device=cuda --function=main             \
 // RUN: | FileCheck %s

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_batch_norm_add_max.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_batch_norm_add_max.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=mhlo        \
+// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=stablehlo   \
 // RUN:              --iree-hal-target-backends=cuda %s                        \
 // RUN: | iree-run-module --module=- --device=cuda --function=main             \
 // RUN: | FileCheck %s

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_batch_norm_expanded.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_batch_norm_expanded.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=mhlo        \
+// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=stablehlo   \
 // RUN:              --iree-hal-target-backends=cuda %s                        \
 // RUN: | iree-run-module --module=- --device=cuda --function=main             \
 // RUN: | FileCheck %s

--- a/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_freduce.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/cudnn/test/conv2d_freduce.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=mhlo        \
+// RUN: iree-compile --iree-plugin=openxla-cudnn --iree-input-type=stablehlo   \
 // RUN:              --iree-hal-target-backends=cuda %s                        \
 // RUN: | iree-run-module --module=- --device=cuda --function=main             \
 // RUN: | FileCheck %s

--- a/runtime/src/openxla/runtime/nvgpu/triton/test/triton_add.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/triton/test/triton_add.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-plugin=openxla-triton --iree-input-type=mhlo       \
+// RUN: iree-compile --iree-plugin=openxla-triton --iree-input-type=stablehlo  \
 // RUN:              --iree-hal-target-backends=cuda %s                        \
 // RUN: | iree-run-module --module=- --device=cuda --function=main             \
 // RUN:                   --input=128xf32=2 --input=128xf32=6                  \

--- a/runtime/src/openxla/runtime/nvgpu/triton/test/triton_custom_call_add.mlir
+++ b/runtime/src/openxla/runtime/nvgpu/triton/test/triton_custom_call_add.mlir
@@ -4,7 +4,7 @@
 
 // RUN: sed 's/#BYTECODE#/'"$BYTECODE"'/g' %s > %t-bytecode.mlir
 
-// RUN: iree-compile --iree-plugin=openxla-triton --iree-input-type=mhlo       \
+// RUN: iree-compile --iree-plugin=openxla-triton --iree-input-type=stablehlo  \
 // RUN:              --iree-hal-target-backends=cuda %t-bytecode.mlir          \
 // RUN: | iree-run-module --module=- --device=cuda --function=main             \
 // RUN:                   --input=128xf32=2 --input=128xf32=6                  \


### PR DESCRIPTION
IREE no longer supports MHLO. Update tests to use stablehlo instead.