### PR TITLE
Implicit Flow-level matmul padding and split-k

### DIFF
--- a/compiler/src/openxla/compiler/nvgpu/Transforms/FlowTransformInterpreter.cpp
+++ b/compiler/src/openxla/compiler/nvgpu/Transforms/FlowTransformInterpreter.cpp
@@ -7,10 +7,14 @@
 #include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
 #include "iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/TransformOps/LinalgMatchOps.h"
+#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Transform/Transforms/TransformInterpreterPassBase.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h"
 #include "mlir/Transforms/Passes.h"
 #include "openxla/compiler/nvgpu/Dialect/FlowTransformExtension/IR/FlowTransformExtension.h"
 #include "openxla/compiler/nvgpu/Transforms/Passes.h"
@@ -36,33 +40,95 @@ static std::pair<Value, Value> buildSelectFirstNonEmpty(ImplicitLocOpBuilder &b,
   return std::make_pair(selector.getFirst(), selector.getRest());
 }
 
-/// Builds transform IR forming dispatch regions for reductions.
-static void buildReductionDispatch(ImplicitLocOpBuilder &builder, Value scopeH,
-                                   bool emitRemarkOnMatch = false) {
-  auto anyOp = transform::AnyOpType::get(builder.getContext());
+/// Build a named transform sequence with the given names and argument/result
+/// types. `inputsConsumed` specifies whether to mark the input as consumed
+/// (true) or readonly (false) and must have as many elements as `inputs`.
+// TODO: add a builder upstream.
+static transform::NamedSequenceOp buildNamedSequence(
+    ImplicitLocOpBuilder &builder, StringRef name, ArrayRef<Type> inputs,
+    ArrayRef<bool> inputsConsumed, ArrayRef<Type> results) {
+  assert(inputs.size() == inputsConsumed.size() &&
+         "expected the same number of consumption flags as input types");
+
+  std::string visibilityString;
+  llvm::raw_string_ostream os(visibilityString);
+  os << SymbolOpInterface::Visibility::Private;
+  os.flush();
+
+  auto unitAttr = builder.getUnitAttr();
+  auto consumedAttr =
+      builder.getStringAttr(transform::TransformDialect::kArgConsumedAttrName);
+  auto readonlyAttr =
+      builder.getStringAttr(transform::TransformDialect::kArgReadOnlyAttrName);
+  auto argAttrs = llvm::to_vector(
+      llvm::map_range(inputsConsumed, [&](bool isConsumed) -> Attribute {
+        return builder.getDictionaryAttr(
+            NamedAttribute(isConsumed ? consumedAttr : readonlyAttr, unitAttr));
+      }));
+
+  auto sequence = builder.create<transform::NamedSequenceOp>(
+      name, TypeAttr::get(builder.getFunctionType(inputs, results)),
+      builder.getStringAttr(visibilityString), builder.getArrayAttr(argAttrs),
+      ArrayAttr());
+  return sequence;
+}
+
+/// Builds transform IR matching the reduction for future dispatch region
+/// formation.
+static transform::NamedSequenceOp buildReductionDispatchMatcher(
+    ImplicitLocOpBuilder &builder, bool emitRemarkOnMatch = false) {
+  auto anyOp = builder.getType<transform::AnyOpType>();
   SmallVector<Type> matchedTypes(4, anyOp);
+  transform::NamedSequenceOp sequence = buildNamedSequence(
+      builder, "match_reduction_partial_nvgpu", {anyOp}, {false}, matchedTypes);
+
+  OpBuilder::InsertionGuard insertionGuard(builder);
+  Block *body = sequence.addEntryBlock();
+  builder.setInsertionPointToEnd(body);
   auto matched = builder.create<transform_ext::MatchCallbackOp>(
-      matchedTypes, "reduction_partial",
-      transform::FailurePropagationMode::Suppress, scopeH);
+      matchedTypes, "reduction_partial_nvgpu",
+      transform::FailurePropagationMode::Propagate, body->getArgument(0));
 
   auto filtered =
       builder.create<transform_dialect::FilterOutAlreadyInDispatchRegionOp>(
           matchedTypes, matched->getResults());
 
   Value reductionH = filtered->getResults().drop_back().back();
-  Value trailingH = filtered->getResults().back();
 
   if (emitRemarkOnMatch) {
     builder.create<transform_ext::EmitRemarkOp>(reductionH,
                                                 "dispatch matched reduction");
   }
 
+  builder.create<transform::YieldOp>(filtered.getResults());
+  return sequence;
+}
+
+/// Builds transform IR creating a dispatch region for a reduction.
+static transform::NamedSequenceOp buildReductionDispatchFormation(
+    ImplicitLocOpBuilder &builder) {
+  auto anyOp = builder.getType<transform::AnyOpType>();
+  SmallVector<Type> matchedTypes(4, anyOp);
+  transform::NamedSequenceOp sequence =
+      buildNamedSequence(builder, "dispatch_reduction_partial_nvgpu",
+                         matchedTypes, {true, true, true, true}, {});
+
+  // This may work because we are always moving _preceding_ ops into the
+  // region. Moving an immediately succeeding op would break the walk by
+  // invalidating the iterator. Also, the actual implementation in the Flow
+  // dialect _clones and erases_, rather than actually _moves_, which can lead
+  // to accidental pointer reuse and other memory problems.
+  OpBuilder::InsertionGuard insertionGuard(builder);
+  Block *body = sequence.addEntryBlock();
+  builder.setInsertionPointToEnd(body);
+  Value reductionH = body->getArguments().drop_back().back();
+  Value trailingH = body->getArguments().back();
   auto [firstH, restH] =
       buildSelectFirstNonEmpty(builder, trailingH, reductionH);
   Value regionH =
       builder.create<transform_dialect::WrapInDispatchRegionOp>(anyOp, firstH);
-  SmallVector<Value> handlesToMerge(filtered->getResults().begin(),
-                                    std::prev(filtered->getResults().end(), 2));
+  SmallVector<Value> handlesToMerge(body->getArguments().begin(),
+                                    std::prev(body->getArguments().end(), 2));
   handlesToMerge.push_back(restH);
   Value mergedHandlesH = builder.create<transform::MergeHandlesOp>(
       handlesToMerge, /*deduplicate=*/false);
@@ -70,6 +136,99 @@ static void buildReductionDispatch(ImplicitLocOpBuilder &builder, Value scopeH,
       builder.create<transform_dialect::MovePrecedingOpIntoDispatchRegionOp>(
           regionH.getType(), mergedHandlesH, regionH);
   builder.create<transform_dialect::RegionToWorkgroupsOp>(anyOp, regionH);
+
+  builder.create<transform::YieldOp>();
+  return sequence;
+}
+
+/// Builds a transform dialect matcher sequence with the given name that matches
+/// a `linalg.matmul` with the given shape.
+// TODO: restrict the elemental type to be f32.
+static transform::NamedSequenceOp buildMatmulMatchers(
+    ImplicitLocOpBuilder &builder, StringRef name, ArrayRef<int64_t> sizes) {
+  auto anyOp = builder.getType<transform::AnyOpType>();
+  auto matchFunction =
+      buildNamedSequence(builder, name, {anyOp}, {false}, {anyOp});
+
+  OpBuilder::InsertionGuard guard(builder);
+  Block *funcBlock = matchFunction.addEntryBlock();
+  builder.setInsertionPointToEnd(funcBlock);
+
+  auto matchStructured = builder.create<transform::MatchStructuredOp>(
+      TypeRange(anyOp), funcBlock->getArgument(0),
+      builder.getAttr<transform::FailurePropagationModeAttr>(
+          transform::FailurePropagationMode::Propagate));
+
+  {
+    OpBuilder::InsertionGuard nestedGuard(builder);
+
+    Block *matcherRegion = builder.createBlock(
+        &matchStructured.getBodyRegion(),
+        matchStructured.getBodyRegion().begin(), {anyOp}, {builder.getLoc()});
+    builder.setInsertionPointToEnd(matcherRegion);
+    builder.create<transform::MatchOperationNameOp>(
+        matcherRegion->getArgument(0),
+        builder.getStrArrayAttr({linalg::MatmulOp::getOperationName()}));
+
+    auto i64Param = builder.getType<transform::ParamType>(builder.getI64Type());
+    for (int64_t i = 0, e = sizes.size(); i < e; ++i) {
+      Value param =
+          builder
+              .create<transform::MatchStructuredDimOp>(
+                  i64Param, matcherRegion->getArgument(0), ArrayRef<int64_t>(i))
+              ->getResult(0);
+      Value constant = builder.create<transform::ParamConstantOp>(
+          i64Param, builder.getI64IntegerAttr(sizes[i]));
+      builder.create<transform::MatchParamCmpIOp>(
+          param, constant, transform::MatchCmpIPredicate::eq);
+    }
+    builder.create<transform::MatchStructuredYieldOp>(
+        matcherRegion->getArgument(0));
+  }
+
+  builder.create<transform::YieldOp>(matchStructured.getResults());
+  return matchFunction;
+}
+
+/// Builds a transform dialect sequence with the given name that pads a matmul
+/// and performs split-k (reduction splitting) if `splitK` is set.
+static transform::NamedSequenceOp buildMatmulPadOptionalSplitK(
+    ImplicitLocOpBuilder &builder, StringRef name, bool splitK) {
+  auto anyOp = builder.getType<transform::AnyOpType>();
+  auto padFunction = buildNamedSequence(builder, name, {anyOp}, {true}, {});
+
+  OpBuilder::InsertionGuard guard(builder);
+  Block *funcBlock = padFunction.addEntryBlock();
+  builder.setInsertionPointToEnd(funcBlock);
+
+  // TODO: add a nicer builder upstream.
+  Attribute f32zero = builder.getF32FloatAttr(0.0);
+  auto i64ArrayAttr = [&](ArrayRef<int64_t> values) {
+    return builder.getArrayAttr(llvm::to_vector(
+        llvm::map_range(values, [&](int64_t value) -> Attribute {
+          return builder.getI64IntegerAttr(value);
+        })));
+  };
+  Value paddedH = builder.create<transform::PadOp>(
+      anyOp, funcBlock->getArgument(0),
+      builder.getArrayAttr({f32zero, f32zero, f32zero}),
+      /*padding_values=*/i64ArrayAttr({0, 1, 2}),
+      /*pad_to_multiple_of*/ i64ArrayAttr({32, 32, 1728}),
+      /*pack_paddings=*/i64ArrayAttr({0, 0, 0}),
+      /*transpose_paddings=*/ArrayAttr());
+
+  if (splitK) {
+    auto split = builder.create<transform::SplitReductionOp>(
+        paddedH, /*splitFactor=*/108, /*insertSplitDimension=*/2);
+    builder.create<transform::InterchangeOp>(
+        anyOp, split.getSplitLinalgOp(),
+        /*iterator_interchange=*/ArrayRef<int64_t>({2, 0, 1, 3}));
+  }
+
+  // TODO: localized cleanups.
+
+  builder.create<transform::YieldOp>();
+  return padFunction;
 }
 
 namespace {
@@ -119,38 +278,97 @@ class TransformDialectPreprocessingPass
         std::make_shared<OwningOpRef<ModuleOp>>(OwningOpRef<ModuleOp>(
             ModuleOp::create(UnknownLoc::get(context), "__transform")));
     OpBuilder builder(context);
+    additionalSharedTransformModule->get()->setAttr(
+        transform::TransformDialect::kWithNamedSequenceAttrName,
+        builder.getUnitAttr());
     builder.setInsertionPointToEnd(
         additionalSharedTransformModule.get()->get().getBody());
     constructTransformModule(builder, UnknownLoc::get(context));
+    if (failed(mlir::verify(additionalSharedTransformModule->get()))) {
+      return failure();
+    }
+
+    if (debugPrintConstructedModule) {
+      additionalSharedTransformModule->get()->print(llvm::outs());
+    }
 
     return r;
   }
 
   void runOnOperation() override {
-    // This may work because we are always moving _preceding_ ops into the
-    // region. Moving an immediately succeeding op would break the walk by
-    // invalidating the iterator. Also, the actual implementation in the Flow
-    // dialect _clones and erases_, rather than actually _moves_, which can lead
-    // to accidental pointer reuse and other memory problems.
-    WalkResult walkResult = getOperation()->walk<WalkOrder::PostOrder>(
-        [&](linalg::LinalgOp linalgOp) {
-          if (failed(transform::detail::interpreterBaseRunOnOperationImpl(
-                  linalgOp, getArgument(), additionalSharedTransformModule,
-                  nullptr,
-                  /*extraMappings=*/{}, options, transformFileName,
-                  transformLibraryFileName, debugPayloadRootTag,
-                  debugTransformRootTag, "iree-opt"))) {
-            return WalkResult::interrupt();
-          }
-          return WalkResult::advance();
-        });
-    if (walkResult.wasInterrupted()) return signalPassFailure();
+    if (failed(transform::detail::interpreterBaseRunOnOperationImpl(
+            getOperation(), getArgument(), additionalSharedTransformModule,
+            nullptr,
+            /*extraMappings=*/{}, options, transformFileName,
+            transformLibraryFileName, debugPayloadRootTag,
+            debugTransformRootTag, "iree-opt"))) {
+      return signalPassFailure();
+    }
   }
 
   /// Constructs the transform module that contains transformation scripts to be
   /// applied.
   std::optional<LogicalResult> constructTransformModule(OpBuilder &builder,
                                                         Location loc) {
+    // Matchers+dispatch builders for each case, ordered by priority.
+    SmallVector<Attribute> matchers;
+    SmallVector<Attribute> actions;
+
+    auto getSymbolRef = [](transform::NamedSequenceOp sequence) {
+      return SymbolRefAttr::get(sequence.getSymNameAttr());
+    };
+
+    auto addRewriteRule = [&](transform::NamedSequenceOp match,
+                              transform::NamedSequenceOp rewrite) {
+      matchers.push_back(getSymbolRef(match));
+      actions.push_back(getSymbolRef(rewrite));
+    };
+    ImplicitLocOpBuilder ib(loc, builder);
+
+    if (enableReductionDispatchFormation) {
+      addRewriteRule(buildReductionDispatchMatcher(ib, debugEmitRemarkOnMatch),
+                     buildReductionDispatchFormation(ib));
+    }
+
+    if (enableMatmulPadSplitK) {
+      // Sizes for which padding is enabled.
+      SmallVector<std::array<int64_t, 3>> padSizes = {{133, 133, 128}};
+      // Sizes for which split-k is enabled.
+      SmallVector<std::array<int64_t, 3>> splitKSizes = {{514, 130, 500},
+                                                         {515, 131, 512}};
+
+      auto makeMatmulMatcher = [&](ArrayRef<int64_t> sizes) -> Attribute {
+        std::string name;
+        llvm::raw_string_ostream os(name);
+        os << "match_matmul_f32_";
+        llvm::interleave(sizes, os, "x");
+        os.flush();
+
+        transform::NamedSequenceOp matcher =
+            buildMatmulMatchers(ib, name, sizes);
+        return SymbolRefAttr::get(matcher.getSymNameAttr());
+      };
+
+      llvm::append_range(matchers,
+                         llvm::map_range(padSizes, makeMatmulMatcher));
+      llvm::append_range(matchers,
+                         llvm::map_range(splitKSizes, makeMatmulMatcher));
+
+      transform::NamedSequenceOp padSequence =
+          buildMatmulPadOptionalSplitK(ib, "matmul_f32_pad", /*splitK=*/false);
+      Attribute padSequenceName =
+          SymbolRefAttr::get(padSequence.getSymNameAttr());
+      actions.append(padSizes.size(), padSequenceName);
+
+      transform::NamedSequenceOp splitKSequence = buildMatmulPadOptionalSplitK(
+          ib, "matmul_f32_split_k", /*splitK=*/true);
+      Attribute splitKSequenceName =
+          SymbolRefAttr::get(splitKSequence.getSymNameAttr());
+      actions.append(splitKSizes.size(), splitKSequenceName);
+    }
+
+    if (matchers.empty()) return std::nullopt;
+
     builder.create<transform::SequenceOp>(
         loc, TypeRange(), transform::FailurePropagationMode::Propagate,
         builder.getType<transform::AnyOpType>(),
@@ -159,11 +377,13 @@ class TransformDialectPreprocessingPass
           ib.create<transform_ext::RegisterMatchCallbacksOp>();
           ib.create<transform_dialect::RegisterNVGPUMatchCallbacks>();
 
-          // Matchers+dispatch builders for each case, ordered by priority.
-          buildReductionDispatch(ib, rootH, debugEmitRemarkOnMatch);
+          b.create<transform::ForeachMatchOp>(loc, rootH.getType(), rootH,
+                                              builder.getArrayAttr(matchers),
+                                              builder.getArrayAttr(actions));
 
           b.create<transform::YieldOp>(loc);
         });
+
     return success();
   }
 

--- a/compiler/src/openxla/compiler/nvgpu/Transforms/Passes.td
+++ b/compiler/src/openxla/compiler/nvgpu/Transforms/Passes.td
@@ -59,7 +59,22 @@ def FlowTransformInterpreterPass
             "top-level transform op.">,
     Option<"debugEmitRemarkOnMatch", "debug-emit-remark-on-match", "bool",
             "false",
-            "Emit remark whenever a subgraph matches a pattern.">
+            "Emit remark whenever a subgraph matches a pattern.">,
+    Option<"debugPrintConstructedModule",
+           "debug-print-constructed-module",
+           "bool",
+           "false",
+           "Print the transform module constructed on-the-fly by the pass.">,
+    Option<"enableReductionDispatchFormation",
+           "enable-reduction-dispatch-formation",
+           "bool",
+           "false",
+           "Enable TD-driven dispatch region formation for reductions.">,
+    Option<"enableMatmulPadSplitK",
+           "enable-matmul-pad-split-k",
+           "bool",
+           "false",
+           "Enable TD-driven graph-level matmul padding and split-K.">
   ];
 }
 

--- a/compiler/src/openxla/compiler/nvgpu/Transforms/test/transform_interpreter_dispatch_reductions.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Transforms/test/transform_interpreter_dispatch_reductions.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(openxla-nvgpu-flow-transform-interpreter,canonicalize,cse)" %s | \
+// RUN: iree-opt --iree-plugin=openxla-transform --pass-pipeline="builtin.module(openxla-nvgpu-flow-transform-interpreter{enable-reduction-dispatch-formation=1},canonicalize,cse)" %s | \
 // RUN: FileCheck %s
 
 // In these tests, occasional use of "check next" inteds to ensure that

--- a/compiler/src/openxla/compiler/nvgpu/Transforms/test/transform_interpreter_matmul_pad_split_k.mlir
+++ b/compiler/src/openxla/compiler/nvgpu/Transforms/test/transform_interpreter_matmul_pad_split_k.mlir
@@ -1,0 +1,128 @@
+// RUN: iree-opt %s --iree-plugin=openxla-transform --openxla-nvgpu-flow-transform-interpreter='enable-matmul-pad-split-k=1' %s | FileCheck %s
+// RUN: iree-opt %s --iree-plugin=openxla-transform --openxla-nvgpu-flow-transform-interpreter='enable-matmul-pad-split-k=1 debug-print-constructed-module=1' %s | FileCheck %s --check-prefix=SCRIPT
+
+// SCRIPT: module @__transform attributes {transform.with_named_sequence}
+
+// SCRIPT-LABEL: transform.named_sequence private @match_matmul_f32_133x133x128
+// SCRIPT-SAME:    (%[[ARG0:.+]]: !transform.any_op {transform.readonly}) -> !transform.any_op
+// SCRIPT:   %[[v0:.+]] = transform.match.structured failures(propagate) %[[ARG0]] : (!transform.any_op) -> !transform.any_op
+// SCRIPT:   ^{{.*}}(%[[ARG1:.+]]: !transform.any_op):
+// SCRIPT:      transform.match.operation_name %[[ARG1]] ["linalg.matmul"] : !transform.any_op
+// SCRIPT:      %[[v1:.+]] = transform.match.structured.dim %[[ARG1]][0] : (!transform.any_op) -> !transform.param<i64>
+// SCRIPT:      %[[v2:.+]] = transform.param.constant 133 : i64 -> !transform.param<i64>
+// SCRIPT:      transform.match.param.cmpi eq %[[v1]], %[[v2]] : !transform.param<i64>
+// SCRIPT:      %[[v3:.+]] = transform.match.structured.dim %[[ARG1]][1]
+// SCRIPT:      %[[v4:.+]] = transform.param.constant 133
+// SCRIPT:      transform.match.param.cmpi eq %[[v3]], %[[v4]]
+// SCRIPT:      %[[v5:.+]] = transform.match.structured.dim %[[ARG1]][2]
+// SCRIPT:      %[[v6:.+]] = transform.param.constant 128
+// SCRIPT:      transform.match.param.cmpi eq %[[v5]], %[[v6]]
+// SCRIPT:      transform.match.structured.yield %[[ARG1]]
+// SCRIPT:    transform.yield %[[v0]] : !transform.any_op
+  
+// SCRIPT-LABEL: transform.named_sequence private @match_matmul_f32_514x130x500
+// SCRIPT-LABEL: transform.named_sequence private @match_matmul_f32_515x131x512
+ 
+// SCRIPT-LABEL: transform.named_sequence private @matmul_f32_pad
+// SCRIPT-SAME:     (%[[ARG0:.+]]: !transform.any_op {transform.consumed})
+// SCRIPT:         %[[v0]] = transform.structured.pad %[[ARG0]] {pack_paddings = [0, 0, 0], pad_to_multiple_of = [32, 32, 1728], padding_dimensions = [0, 1, 2], padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]} : (!transform.any_op) -> !transform.any_op
+// SCRIPT:         transform.yield 
+  
+// SCRIPT-LABEL: transform.named_sequence private @matmul_f32_split_k
+// SCRIPT-SAME: (%[[ARG0:.+]]: !transform.any_op {transform.consumed})
+// SCRIPT:        %[[v0:.+]] = transform.structured.pad %arg0 {pack_paddings = [0, 0, 0], pad_to_multiple_of = [32, 32, 1728], padding_dimensions = [0, 1, 2], padding_values = [0.000000e+00 : f32, 0.000000e+00 : f32, 0.000000e+00 : f32]} : (!transform.any_op) -> !transform.any_op
+// SCRIPT:        %{{.*}}, %{{.*}}, %[[SPLIT:.+]], %{{.*}} = transform.structured.split_reduction %0 {insert_split_dimension = 2 : i64, split_factor = 108 : i64} : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op, !transform.any_op)
+// SCRIPT:        transform.structured.interchange %[[SPLIT]] iterator_interchange = [2, 0, 1, 3] : (!transform.any_op) -> !transform.any_op
+// SCRIPT:        transform.yield 
+  
+// SCRIPT:  transform.sequence  failures(propagate)
+// SCRIPT:  ^{{.*}}(%[[ARG0:.+]]: !transform.any_op):
+// SCRIPT:    transform.iree.register_match_callbacks
+// SCRIPT:    transform.iree.register_nvgpu_match_callbacks
+// SCRIPT:    foreach_match in %[[ARG0]]
+// SCRIPT:        @match_matmul_f32_133x133x128 -> @matmul_f32_pad, 
+// SCRIPT:        @match_matmul_f32_514x130x500 -> @matmul_f32_split_k, 
+// SCRIPT:        @match_matmul_f32_515x131x512 -> @matmul_f32_split_k
+  
+
+
+!A_t = tensor<514x500xf32>
+!B_t = tensor<500x130xf32>
+!C_t = tensor<514x130xf32>
+
+func.func @matmul_static(
+    %A : !A_t, %B : !B_t, %C : !C_t) -> !C_t {
+  %0 = linalg.matmul ins(%A, %B : !A_t, !B_t)
+                     outs(%C : !C_t) -> !C_t
+  return %0 : !C_t
+}
+
+// CHECK-LABEL: @matmul_static
+// CHECK: %[[padded_lhs:.+]] = tensor.pad
+// CHECK: %[[padded_rhs:.+]] = tensor.pad
+// CHECK: %[[padded_res:.+]] = tensor.pad
+// CHECK: %[[expanded_lhs:.+]] = tensor.expand_shape %[[padded_lhs]] {{.*}} : tensor<544x1728xf32> into tensor<544x108x16xf32>
+// CHECK: %[[expanded_rhs:.+]] = tensor.expand_shape %[[padded_rhs]] {{.*}} : tensor<1728x160xf32> into tensor<108x16x160xf32>
+// CHECK: linalg.generic
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[expanded_lhs]], %[[expanded_rhs]]
+// CHECK: linalg.generic
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK-SAME: outs(%[[padded_res]]
+
+func.func @fill_matmul_static(
+    %A : !A_t, %B : !B_t, %C : !C_t) -> !C_t {
+  %f0 = arith.constant 0.0 : f32
+  %out = tensor.empty() : !C_t
+  %filled = linalg.fill ins(%f0 : f32) outs(%out : !C_t) -> !C_t
+  %0 = linalg.matmul ins(%A, %B : !A_t, !B_t)
+                     outs(%filled : !C_t) -> !C_t
+  return %0 : !C_t
+}
+
+// CHECK-LABEL: @fill_matmul_static
+// CHECK: %[[padded_lhs:.+]] = tensor.pad
+// CHECK: %[[padded_rhs:.+]] = tensor.pad
+// CHECK: %[[padded_res:.+]] = tensor.pad
+// CHECK: %[[expanded_lhs:.+]] = tensor.expand_shape %[[padded_lhs]] {{.*}} : tensor<544x1728xf32> into tensor<544x108x16xf32>
+// CHECK: %[[expanded_rhs:.+]] = tensor.expand_shape %[[padded_rhs]] {{.*}} : tensor<1728x160xf32> into tensor<108x16x160xf32>
+// CHECK: linalg.fill {{.*}} -> tensor<544x160x108xf32>
+// CHECK: linalg.generic
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+// CHECK-SAME: ins(%[[expanded_lhs]], %[[expanded_rhs]]
+// CHECK: linalg.generic
+// CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+// CHECK-SAME: outs(%[[padded_res]]
+
+// -----
+
+!A_t = tensor<133x128xf32>
+!B_t = tensor<128x133xf32>
+!C_t = tensor<133x133xf32>
+
+// CHECK-LABEL: @matmul_static_pad
+// CHECK-COUNT-3: tensor.pad
+// CHECK: linalg.matmul
+func.func @matmul_static_pad(
+    %A : !A_t, %B : !B_t, %C : !C_t) -> !C_t {
+  %0 = linalg.matmul ins(%A, %B : !A_t, !B_t)
+                     outs(%C : !C_t) -> !C_t
+  return %0 : !C_t
+}
+
+// -----
+
+
+!A_t = tensor<128x128xf32>
+!B_t = tensor<128x128xf32>
+!C_t = tensor<128x128xf32>
+
+// CHECK-LABEL: @matmul_static_nopad
+// CHECK-NOT: tensor.pad
+// CHECK: linalg.matmul
+func.func @matmul_static_nopad(
+    %A : !A_t, %B : !B_t, %C : !C_t) -> !C_t {
+  %0 = linalg.matmul ins(%A, %B : !A_t, !B_t)
+                     outs(%C : !C_t) -> !C_t
+  return %0 : !C_t
+}


### PR DESCRIPTION
This uses transform matcher operations instead of C++ to identify matmuls where it can apply for a more self-consistent TD experience. As a result, it also reworks the flow pass so the IR walk is done in the transform operation rather than in the pass.

This is blocked until IREE advances past https://github.com/llvm/llvm-project/commit/135e5bf8940f3d965c44e31eb4c94b8f8388a100.